### PR TITLE
Add Unravel.AspNet.Mvc with Dependency Resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ We'll see how close we can get…
     }
     ```
 
+## Unravel.AspNet.Mvc
+
+Similar to ASP.NET Core 2.1's [`AddMvc()`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.mvcservicecollectionextensions.addmvc?view=aspnetcore-2.1), Unravel provides an `AddAspNetMvc()` extension method on `IServiceCollection` that registers an `IDependencyResolver`.
+
+The resulting `IAspNetMvcBuilder` is similar to [`IMvcBuilder`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.imvcbuilder?view=aspnetcore-2.1), providing an extension point for additional configuration:
+
+- [`AddControllersAsServices()`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.mvccoremvcbuilderextensions.addcontrollersasservices?view=aspnetcore-2.1)
+
+```csharp
+public override void ConfigureServices(IServiceCollection services)
+{
+    services.AddAspNetMvc()
+        .AddControllersAsServices();
+}
+```
+
 ## Credits
 
 - `Startup` concept from [Arex388.AspNet.Mvc.Startup](https://github.com/arex388/Arex388.AspNet.Mvc.Startup)

--- a/Unravel.sln
+++ b/Unravel.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnravelExamples.Web", "exam
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Unravel.Startup", "src\Startup\Unravel.Startup.csproj", "{06797441-1726-4BD0-A74D-21E211756367}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Unravel.AspNet.Mvc", "src\AspNet.Mvc\Unravel.AspNet.Mvc.csproj", "{3372BA01-9E2B-48C8-A365-E36141BA32D1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,18 @@ Global
 		{06797441-1726-4BD0-A74D-21E211756367}.Release|x64.Build.0 = Release|Any CPU
 		{06797441-1726-4BD0-A74D-21E211756367}.Release|x86.ActiveCfg = Release|Any CPU
 		{06797441-1726-4BD0-A74D-21E211756367}.Release|x86.Build.0 = Release|Any CPU
+		{3372BA01-9E2B-48C8-A365-E36141BA32D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3372BA01-9E2B-48C8-A365-E36141BA32D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3372BA01-9E2B-48C8-A365-E36141BA32D1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3372BA01-9E2B-48C8-A365-E36141BA32D1}.Debug|x64.Build.0 = Debug|Any CPU
+		{3372BA01-9E2B-48C8-A365-E36141BA32D1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3372BA01-9E2B-48C8-A365-E36141BA32D1}.Debug|x86.Build.0 = Debug|Any CPU
+		{3372BA01-9E2B-48C8-A365-E36141BA32D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3372BA01-9E2B-48C8-A365-E36141BA32D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3372BA01-9E2B-48C8-A365-E36141BA32D1}.Release|x64.ActiveCfg = Release|Any CPU
+		{3372BA01-9E2B-48C8-A365-E36141BA32D1}.Release|x64.Build.0 = Release|Any CPU
+		{3372BA01-9E2B-48C8-A365-E36141BA32D1}.Release|x86.ActiveCfg = Release|Any CPU
+		{3372BA01-9E2B-48C8-A365-E36141BA32D1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/examples/Web/Content/Site.css
+++ b/examples/Web/Content/Site.css
@@ -18,6 +18,10 @@ h1 {
     margin: 10px 0;
 }
 
+a {
+    text-decoration: none;
+}
+
 iframe {
     border: none rebeccapurple 2px;
     border-top-style: solid;

--- a/examples/Web/Controllers/AspNetTestController.cs
+++ b/examples/Web/Controllers/AspNetTestController.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Web;
+using System.Web.Mvc;
+using Unravel;
+using UnravelExamples.Web.Services;
+
+namespace UnravelExamples.Web.Controllers
+{
+    public class AspNetTestController : Controller
+    {
+        private readonly IServiceProvider services;
+
+        public AspNetTestController(IServiceProvider services)
+        {
+            this.services = services;
+        }
+
+        public ActionResult Index()
+        {
+            var env = new EnvironmentCheck("ASP.NET Controller Injection", services);
+            return Content(env.ToString(), "application/json; charset=utf-8");
+        }
+    }
+}

--- a/examples/Web/Startup.cs
+++ b/examples/Web/Startup.cs
@@ -9,6 +9,9 @@ namespace UnravelExamples.Web
         public override void ConfigureServices(IServiceCollection services)
         {
             Counters.Register(services);
+
+            services.AddAspNetMvc()
+                ;
         }
 
         public override void ConfigureOwin(IAppBuilder app)

--- a/examples/Web/Startup.cs
+++ b/examples/Web/Startup.cs
@@ -11,6 +11,7 @@ namespace UnravelExamples.Web
             Counters.Register(services);
 
             services.AddAspNetMvc()
+                .AddControllersAsServices()
                 ;
         }
 

--- a/examples/Web/UnravelExamples.Web.csproj
+++ b/examples/Web/UnravelExamples.Web.csproj
@@ -290,6 +290,10 @@
     <Content Include="App.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\AspNet.Mvc\Unravel.AspNet.Mvc.csproj">
+      <Project>{3372ba01-9e2b-48c8-a365-e36141ba32d1}</Project>
+      <Name>Unravel.AspNet.Mvc</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\Startup\Unravel.Startup.csproj">
       <Project>{06797441-1726-4bd0-a74d-21e211756367}</Project>
       <Name>Unravel.Startup</Name>

--- a/examples/Web/UnravelExamples.Web.csproj
+++ b/examples/Web/UnravelExamples.Web.csproj
@@ -248,6 +248,7 @@
     <Compile Include="App_Start\FilterConfig.cs" />
     <Compile Include="App_Start\RouteConfig.cs" />
     <Compile Include="App_Start\WebApiConfig.cs" />
+    <Compile Include="Controllers\AspNetTestController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>

--- a/examples/Web/Views/Home/Index.cshtml
+++ b/examples/Web/Views/Home/Index.cshtml
@@ -11,6 +11,7 @@
         <li><a target="env" href="@Url.Action(nameof(HomeController.HttpContext_Current_GetRequestServices))"><code>HttpContext.GetRequestServices()</code></a></li>
         <li><a target="env" href="@Url.Action(nameof(HomeController.HttpContextBase_GetRequestServices))"><code>HttpContextBase.GetRequestServices()</code></a></li>
         <li><a target="env" href="@Url.Action(nameof(HomeController.Throw))"><code>throw</code></a></li>
+        <li><a target="env" href="@Url.Action(nameof(AspNetTestController.Index), "AspNetTest")">Constructor Injection</a></li>
     </ul>
 
     <h2>OWIN</h2>

--- a/src/AspNet.Mvc/DependencyInjection/IAspNetMvcBuilder.cs
+++ b/src/AspNet.Mvc/DependencyInjection/IAspNetMvcBuilder.cs
@@ -1,0 +1,13 @@
+﻿namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    ///   An interface for configuring ASP.NET MVC services.
+    /// </summary>
+    public interface IAspNetMvcBuilder
+    {
+        /// <summary>
+        ///   Gets the <see cref="IServiceCollection"/> where ASP.NET MVC services are configured.
+        /// </summary>
+        IServiceCollection Services { get; }
+    }
+}

--- a/src/AspNet.Mvc/DependencyInjection/Internal/AspNetMvcBuilder.cs
+++ b/src/AspNet.Mvc/DependencyInjection/Internal/AspNetMvcBuilder.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Unravel.AspNet.Mvc.DependencyInjection.Internal
+{
+    /// <summary>
+    ///   Allows fine grained configuration of ASP.NET MVC services.
+    /// </summary>
+    public class AspNetMvcBuilder : IAspNetMvcBuilder
+    {
+        /// <summary>
+        ///   Initializes a new <see cref="AspNetMvcBuilder"/> instance.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        public AspNetMvcBuilder(IServiceCollection services)
+        {
+            Services = services;
+        }
+
+        /// <inheritdoc/>
+        public IServiceCollection Services { get; }
+    }
+}

--- a/src/AspNet.Mvc/DependencyInjection/Internal/DependencyResolverStartupFilter.cs
+++ b/src/AspNet.Mvc/DependencyInjection/Internal/DependencyResolverStartupFilter.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Web.Mvc;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Unravel.AspNet.Mvc.DependencyInjection.Internal
+{
+    public class DependencyResolverStartupFilter : IStartupFilter
+    {
+        /// <summary>
+        ///   Calls <see cref="DependencyResolver.SetResolver(IDependencyResolver)"/>
+        ///   with an <see cref="IDependencyResolver"/> from
+        ///   <see cref="IApplicationBuilder.ApplicationServices"/>, if available.
+        /// </summary>
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+        {
+            return SetDependencyResolver;
+
+            void SetDependencyResolver(IApplicationBuilder builder)
+            {
+                var resolver = builder.ApplicationServices.GetService<IDependencyResolver>();
+                if (resolver != null)
+                    DependencyResolver.SetResolver(resolver);
+
+                next(builder);
+            }
+        }
+    }
+}

--- a/src/AspNet.Mvc/DependencyInjection/Internal/ServiceProviderDependencyResolver.cs
+++ b/src/AspNet.Mvc/DependencyInjection/Internal/ServiceProviderDependencyResolver.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Web;
+using System.Web.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Unravel.AspNet.Mvc.DependencyInjection.Internal
+{
+    public sealed class ServiceProviderDependencyResolver : IDependencyResolver
+    {
+        /// <inheritdoc/>
+        public object GetService(Type serviceType) =>
+            HttpContext.Current.GetRequestServices()
+                .GetService(serviceType);
+
+        /// <inheritdoc/>
+        public IEnumerable<object> GetServices(Type serviceType) =>
+            HttpContext.Current.GetRequestServices()
+                .GetServices(serviceType);
+    }
+}

--- a/src/AspNet.Mvc/DependencyInjection/UnravelAspNetMvcBuilderExtensions.cs
+++ b/src/AspNet.Mvc/DependencyInjection/UnravelAspNetMvcBuilderExtensions.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Web.Mvc;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    ///   Extensions for configuring ASP.NET MVC using an <see cref="IAspNetMvcBuilder"/>.
+    /// </summary>
+    public static class UnravelAspNetMvcBuilderExtensions
+    {
+        /// <summary>
+        ///   Registers controllers discovered in <see cref="IHostingEnvironment.ApplicationName"/>
+        ///   as services in the <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="builder">The <see cref="IAspNetMvcBuilder"/>.</param>
+        /// <returns>The <see cref="IAspNetMvcBuilder"/>.</returns>
+        public static IAspNetMvcBuilder AddControllersAsServices(this IAspNetMvcBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            // https://github.com/dotnet/aspnetcore/blob/c2cfc5f140cd2743ecc33eeeb49c5a2dd35b017f/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs#L83-L90
+            var environment = GetServiceFromCollection<IHostingEnvironment>(builder.Services);
+            var entryAssemblyName = environment?.ApplicationName;
+            if (string.IsNullOrEmpty(entryAssemblyName))
+                return builder;
+
+            var entryAssembly = Assembly.Load(new AssemblyName(entryAssemblyName));
+            return builder.AddControllersAsServices(entryAssembly);
+        }
+
+        /// <summary>
+        ///   Registers controllers discovered in <paramref name="assembly"/>
+        ///   as services in the <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="builder">The <see cref="IAspNetMvcBuilder"/>.</param>
+        /// <param name="assembly">The <see cref="Assembly"/> to scan.</param>
+        /// <returns>The <see cref="IAspNetMvcBuilder"/>.</returns>
+        public static IAspNetMvcBuilder AddControllersAsServices(this IAspNetMvcBuilder builder, Assembly assembly)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (assembly == null)
+            {
+                throw new ArgumentNullException(nameof(assembly));
+            }
+
+            var services = builder.Services;
+
+            var controllerType = typeof(IController);
+
+            foreach (var type in assembly.GetExportedTypes())
+            {
+                if (type.IsAbstract || type.IsGenericTypeDefinition)
+                    continue;
+
+                if (!controllerType.IsAssignableFrom(type))
+                    continue;
+
+                if (!type.Name.EndsWith("Controller", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                services.AddTransient(type);
+            }
+
+            return builder;
+        }
+
+        private static T GetServiceFromCollection<T>(IServiceCollection services)
+        {
+            return (T)services
+                .LastOrDefault(d => d.ServiceType == typeof(T))
+                ?.ImplementationInstance;
+        }
+    }
+}

--- a/src/AspNet.Mvc/DependencyInjection/UnravelAspNetMvcServiceCollectionExtensions.cs
+++ b/src/AspNet.Mvc/DependencyInjection/UnravelAspNetMvcServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System.Web.Mvc;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Unravel.AspNet.Mvc.DependencyInjection.Internal;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    ///   Extension methods for setting up ASP.NET MVC services in an <see cref="IServiceCollection" />.
+    /// </summary>
+    public static class UnravelAspNetMvcServiceCollectionExtensions
+    {
+        /// <summary>
+        ///   Adds ASP.NET MVC services to the specified <see cref="IServiceCollection" />, including:
+        ///   <list type="bullet">
+        ///     <item><see cref="DependencyResolverStartupFilter"/> as <see cref="IStartupFilter"/></item>
+        ///     <item><see cref="ServiceProviderDependencyResolver"/> as <see cref="IDependencyResolver"/></item>
+        ///   </list>
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <returns>An <see cref="IAspNetMvcBuilder"/> that can be used to further configure the MVC services.</returns>
+        public static IAspNetMvcBuilder AddAspNetMvc(this IServiceCollection services)
+        {
+            services.AddSingleton<IStartupFilter, DependencyResolverStartupFilter>();
+            services.TryAddSingleton<IDependencyResolver, ServiceProviderDependencyResolver>();
+
+            return new AspNetMvcBuilder(services);
+        }
+    }
+}

--- a/src/AspNet.Mvc/Unravel.AspNet.Mvc.csproj
+++ b/src/AspNet.Mvc/Unravel.AspNet.Mvc.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <AssemblyName>Unravel.AspNet.Mvc</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Startup\Unravel.Startup.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/AspNet.Mvc/Unravel.AspNet.Mvc.csproj
+++ b/src/AspNet.Mvc/Unravel.AspNet.Mvc.csproj
@@ -6,7 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.7" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Startup\Unravel.Startup.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Web" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Starting a new project for MVC-specific stuff.

This is probably more flexibility than anyone actually needs, but I'm using an `IStartupFilter` to call `DependencyResolver.SetResolver()` with whatever `IDependencyResolver` we're able to resolve from `ApplicationServices`. The vast majority of the time that will find the one we register, which resolves services from `HttpContext.Current`, as implemented in #2.