### PR TITLE
Host ASP.NET Core 2.1 in OWIN on System.Web

### DIFF
--- a/examples/Web/Services/EnvironmentAspNetCore.cs
+++ b/examples/Web/Services/EnvironmentAspNetCore.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Linq;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+
+namespace UnravelExamples.Web.Services
+{
+    public class EnvironmentAspNetCore : EnvironmentBase
+    {
+        public EnvironmentAspNetCore(IServiceProvider services) : base(services)
+        {
+            Server = services.GetService<IServer>();
+            HttpContext = services.GetService<IHttpContextAccessor>()?.HttpContext;
+            HttpRequest = HttpContext?.Request;
+        }
+
+        public IServer Server { get; }
+        public HttpContext HttpContext { get; }
+        public HttpRequest HttpRequest { get; }
+
+        public override string EnvironmentName => "Microsoft.AspNetCore";
+
+        public override JToken ToJson()
+        {
+            return new JObject
+            {
+                { nameof(IServer), Server?.ToString() },
+                {
+                    nameof(HttpContext),
+                    HttpContext == null ?
+                        null :
+                        JObject.FromObject(HttpContext.Features.ToDictionary(kvp => kvp.Key.Name, kvp => kvp.Value.GetType().FullName))
+                },
+                {
+                    nameof(HttpRequest),
+                    HttpRequest == null ?
+                        null :
+                        JObject.FromObject(new
+                        {
+                            HttpRequest?.PathBase,
+                            HttpRequest?.Path,
+                        })
+                },
+                { nameof(HttpContext.User), ToJson(HttpContext?.User) },
+            };
+        }
+    }
+}

--- a/examples/Web/Services/EnvironmentCheck.cs
+++ b/examples/Web/Services/EnvironmentCheck.cs
@@ -37,6 +37,7 @@ namespace UnravelExamples.Web.Services
 
             yield return new EnvironmentSystemWeb(Services);
             yield return new EnvironmentOwin(Services);
+            yield return new EnvironmentAspNetCore(Services);
             yield return new EnvironmentConfiguration(Services);
             yield return new EnvironmentLogging(Services);
         }

--- a/examples/Web/Startup.AspNetCore.cs
+++ b/examples/Web/Startup.AspNetCore.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Owin;
+using UnravelExamples.Web.Services;
+
+namespace UnravelExamples.Web
+{
+    public partial class Startup
+    {
+        private static void AspNetCoreTestRoutes(IApplicationBuilder app)
+        {
+            var logger = app.ApplicationServices.GetRequiredService<ILoggerFactory>().CreateLogger<Startup>();
+            app.Run((HttpContext context) =>
+            {
+                context.Response.Headers["Content-Type"] = "application/json; charset=utf-8";
+
+                var starting = false;
+                var completed = false;
+                context.Response.OnStarting(() =>
+                {
+                    if (completed)
+                        throw new InvalidOperationException("OnCompleted before OnStarting!");
+
+                    starting = true;
+                    logger.LogInformation("{0} OnStarting", context.Request.Path);
+                    return Task.CompletedTask;
+                });
+
+                context.Response.OnCompleted(() =>
+                {
+                    if (!starting)
+                        throw new InvalidOperationException("OnCompleted before OnStarting!");
+
+                    completed = true;
+                    logger.LogInformation("{0} OnCompleting", context.Request.Path);
+                    return Task.CompletedTask;
+                });
+
+
+                switch (context.Request.Path)
+                {
+                    case "/Startup_Services":
+                        return WriteEnvironment("Startup.Services", Services);
+                    case "/IApplicationBuilder_ApplicationServices":
+                        return WriteEnvironment("IApplicationBuilder.ApplicationServices", app.ApplicationServices);
+                    case "/HttpContext_RequestServices":
+                        return WriteEnvironment("HttpContext.RequestServices", context.RequestServices);
+                    case "/Throw":
+                        throw new ApplicationException("From ASP.NET Core");
+                    default:
+                        context.Response.StatusCode = 404;
+                        return context.Response.WriteAsync("Not Found");
+                }
+
+                Task WriteEnvironment(string title, IServiceProvider services)
+                {
+                    var env = new EnvironmentCheck(title, services);
+                    return context.Response.WriteAsync(env.ToString());
+                }
+            });
+        }
+    }
+}

--- a/examples/Web/Startup.cs
+++ b/examples/Web/Startup.cs
@@ -23,6 +23,8 @@ namespace UnravelExamples.Web
             app.Map("/OWIN", OwinTestRoutes);
 
             app.UseAspNetCore();
+
+            app.Map("/OWIN-after-UseAspNetCore", OwinTestRoutes);
         }
 
         public override void Configure(IApplicationBuilder app)

--- a/examples/Web/Startup.cs
+++ b/examples/Web/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
 using Owin;
 using UnravelExamples.Web.Services;
 
@@ -13,11 +14,20 @@ namespace UnravelExamples.Web
             services.AddAspNetMvc()
                 .AddControllersAsServices()
                 ;
+
+            services.AddHttpContextAccessor();
         }
 
         public override void ConfigureOwin(IAppBuilder app)
         {
             app.Map("/OWIN", OwinTestRoutes);
+
+            app.UseAspNetCore();
+        }
+
+        public override void Configure(IApplicationBuilder app)
+        {
+            app.Map("/AspNetCore", AspNetCoreTestRoutes);
         }
     }
 }

--- a/examples/Web/UnravelExamples.Web.csproj
+++ b/examples/Web/UnravelExamples.Web.csproj
@@ -255,6 +255,7 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\Counters.cs" />
+    <Compile Include="Services\EnvironmentAspNetCore.cs" />
     <Compile Include="Services\EnvironmentBase.cs" />
     <Compile Include="Services\EnvironmentCheck.cs" />
     <Compile Include="Services\EnvironmentConfiguration.cs" />
@@ -263,6 +264,7 @@
     <Compile Include="Services\EnvironmentOwin.cs" />
     <Compile Include="Services\EnvironmentSystemWeb.cs" />
     <Compile Include="Services\ServiceProviderExtensions.cs" />
+    <Compile Include="Startup.AspNetCore.cs" />
     <Compile Include="Startup.cs" />
     <Compile Include="Startup.Owin.cs" />
   </ItemGroup>

--- a/examples/Web/Views/Home/Index.cshtml
+++ b/examples/Web/Views/Home/Index.cshtml
@@ -21,6 +21,14 @@
         <li><a target="env" href="/OWIN/IOwinContext_GetRequestServices"><code>IOwinContext.GetRequestServices()</code></a></li>
         <li><a target="env" href="/OWIN/Throw"><code>throw</code></a></li>
     </ul>
+
+    <h2>ASP.NET Core</h2>
+    <ul>
+        <li><a target="env" href="/AspNetCore/Startup_Services"><code>Startup.Services</code></a></li>
+        <li><a target="env" href="/AspNetCore/IApplicationBuilder_ApplicationServices"><code>IApplicationBuilder.ApplicationServices</code></a></li>
+        <li><a target="env" href="/AspNetCore/HttpContext_RequestServices"><code>HttpContext.RequestServices</code></a></li>
+        <li><a target="env" href="/AspNetCore/Throw"><code>throw</code></a></li>
+    </ul>
 </nav>
 
 <iframe name="env"

--- a/examples/Web/Views/Home/Index.cshtml
+++ b/examples/Web/Views/Home/Index.cshtml
@@ -29,6 +29,14 @@
         <li><a target="env" href="/AspNetCore/HttpContext_RequestServices"><code>HttpContext.RequestServices</code></a></li>
         <li><a target="env" href="/AspNetCore/Throw"><code>throw</code></a></li>
     </ul>
+
+    <h2>OWIN after <code>UseAspNetCore()</code></h2>
+    <ul>
+        <li><a target="env" href="/OWIN-after-UseAspNetCore/Startup_Services"><code>Startup.Services</code></a></li>
+        <li><a target="env" href="/OWIN-after-UseAspNetCore/IAppBuilder_GetApplicationServices"><code>IAppBuilder.GetApplicationServices()</code></a></li>
+        <li><a target="env" href="/OWIN-after-UseAspNetCore/IOwinContext_GetRequestServices"><code>IOwinContext.GetRequestServices()</code></a></li>
+        <li><a target="env" href="/OWIN-after-UseAspNetCore/Throw"><code>throw</code></a></li>
+    </ul>
 </nav>
 
 <iframe name="env"

--- a/src/Startup/Hosting/OwinServer.cs
+++ b/src/Startup/Hosting/OwinServer.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
+using Unravel.Owin;
 
 namespace Unravel.Hosting
 {
@@ -23,6 +24,8 @@ namespace Unravel.Hosting
         public virtual Task StartAsync<TContext>(IHttpApplication<TContext> application, CancellationToken cancellationToken)
         {
             logger.LogTrace(nameof(StartAsync));
+
+            Features.Set<IOwinMiddlewareFeature>(new OwinMiddlewareFeature<TContext>(application));
 
             return Task.CompletedTask;
         }

--- a/src/Startup/Hosting/OwinServer.cs
+++ b/src/Startup/Hosting/OwinServer.cs
@@ -10,10 +10,12 @@ namespace Unravel.Hosting
 {
     public class OwinServer : IServer
     {
+        private readonly ILoggerFactory loggerFactory;
         private readonly ILogger<OwinServer> logger;
 
         public OwinServer(ILoggerFactory loggerFactory)
         {
+            this.loggerFactory = loggerFactory;
             logger = loggerFactory.CreateLogger<OwinServer>();
 
             // TODO: Set<IServerAddressesFeature>()?
@@ -25,7 +27,7 @@ namespace Unravel.Hosting
         {
             logger.LogTrace(nameof(StartAsync));
 
-            Features.Set<IOwinMiddlewareFeature>(new OwinMiddlewareFeature<TContext>(application));
+            Features.Set<IOwinMiddlewareFeature>(new OwinMiddlewareFeature<TContext>(application, loggerFactory));
 
             return Task.CompletedTask;
         }

--- a/src/Startup/Owin/IOwinMiddlewareFeature.cs
+++ b/src/Startup/Owin/IOwinMiddlewareFeature.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Owin.Builder;
+using Owin;
+
+namespace Unravel.Owin
+{
+    /// <summary>
+    ///   Provides a middleware node to be added to the OWIN function pipeline by
+    ///   <see cref="OwinAspNetCoreExtensions.UseAspNetCore(IAppBuilder, object[])"/>.
+    ///   Middleware can receive additional <c>args</c> from <c>UseAspNetCore()</c>.
+    /// </summary>
+    public interface IOwinMiddlewareFeature
+    {
+        /// <summary>
+        ///   The middleware passed to <see cref="IAppBuilder.Use(object, object[])"/>.
+        ///   See <see cref="AppBuilder.Use(object, object[])"/> for documentation.
+        /// </summary>
+        object OwinMiddleware { get; }
+    }
+}

--- a/src/Startup/Owin/OwinAspNetCoreExtensions.cs
+++ b/src/Startup/Owin/OwinAspNetCoreExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.Extensions.DependencyInjection;
+using Unravel.Owin;
+
+namespace Owin
+{
+    public static class OwinAspNetCoreExtensions
+    {
+        /// <summary>
+        ///   Inserts ASP.NET Core processing into the OWIN pipeline using
+        ///   <see cref="IOwinMiddlewareFeature.OwinMiddleware"/>.
+        ///   The default middleware ignores <paramref name="args"/>.
+        /// </summary>
+        /// <param name="app">The <see cref="IAppBuilder"/>.</param>
+        /// <param name="args">
+        ///   See <see cref="AppBuilder.Use(object, object[])"/> for documentation.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        ///   <see cref="IOwinMiddlewareFeature"/> was not found in <see cref="IServer.Features"/>.
+        /// </exception>
+        public static void UseAspNetCore(this IAppBuilder app, params object[] args)
+        {
+            if (app == null) throw new ArgumentNullException(nameof(app));
+
+            var server = app.GetApplicationServices().GetRequiredService<IServer>();
+
+            var feature = server.Features.Get<IOwinMiddlewareFeature>()
+                ?? throw new InvalidOperationException($"Server does not support {nameof(IOwinMiddlewareFeature)}.");
+
+            app.Use(feature.OwinMiddleware, args);
+        }
+    }
+}

--- a/src/Startup/Owin/OwinMiddlewareFeature.cs
+++ b/src/Startup/Owin/OwinMiddlewareFeature.cs
@@ -70,8 +70,10 @@ namespace Unravel.Owin
                     throw;
                 }
 
-                // TODO: Need a more robust check
-                if (response.StatusCode == 404)
+                // The base RequestDelegate only sets StatusCode = 404:
+                // https://github.com/dotnet/aspnetcore/blob/c2cfc5f140cd2743ecc33eeeb49c5a2dd35b017f/src/Http/Http/src/Internal/ApplicationBuilder.cs#L82-L86
+                // If we still have 404 and Body hasn't been accessed, let the OWIN pipeline continue
+                if (response.StatusCode == 404 && !response.AssumeBodyModified)
                 {
                     // Reset to prior OWIN status
                     response.StatusCode = initialStatus;

--- a/src/Startup/Owin/OwinMiddlewareFeature.cs
+++ b/src/Startup/Owin/OwinMiddlewareFeature.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Owin;
+
+namespace Unravel.Owin
+{
+    using AppFunc = Func<IDictionary<string, object>, Task>;
+
+    /// <summary>
+    ///   Provides an OWIN middleware that processes requests with the given
+    ///   <see cref="IHttpApplication{TContext}"/>.
+    ///   Context is created with <see cref="OwinFeatureCollection"/>.
+    /// </summary>
+    /// <typeparam name="TContext">The context associated with the application.</typeparam>
+    public class OwinMiddlewareFeature<TContext> : IOwinMiddlewareFeature
+    {
+        private readonly IHttpApplication<TContext> application;
+
+        public OwinMiddlewareFeature(IHttpApplication<TContext> application)
+        {
+            this.application = application;
+        }
+
+        object IOwinMiddlewareFeature.OwinMiddleware => new Func<AppFunc, AppFunc>(Invoke);
+
+        public AppFunc Invoke(AppFunc next)
+        {
+            // https://github.com/dotnet/AspNetCore.Docs/blob/55e9843af1055d38d33450497850bd4295d0f5fe/aspnetcore/fundamentals/owin/sample/src/NowinSample/NowinServer.cs#L32-L50
+            return async env =>
+            {
+                // The reason for 2 level of wrapping is because the OwinFeatureCollection isn't mutable
+                // so features can't be added
+                var owinFeatures = new OwinFeatureCollection(env);
+                var features = new FeatureCollection(owinFeatures);
+
+                var response = features.Get<IHttpResponseFeature>();
+
+                var initialStatus = response.StatusCode; // Incoming OWIN status (typically 200)
+
+                var context = application.CreateContext(features);
+
+                // From: https://github.com/dotnet/aspnetcore/blob/c2cfc5f140cd2743ecc33eeeb49c5a2dd35b017f/src/Hosting/TestHost/src/HttpContextBuilder.cs#L67-L77
+                // TODO: https://github.com/dotnet/aspnetcore/blob/ccfb12cf73b0285c981c70a2061312a837510f7b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs#L662-L756
+                try
+                {
+                    await application.ProcessRequestAsync(context);
+
+                    application.DisposeContext(context, null);
+                }
+                catch (Exception ex)
+                {
+                    application.DisposeContext(context, ex);
+                    throw;
+                }
+
+                // TODO: Need a more robust check
+                if (response.StatusCode == 404)
+                {
+                    // Reset to prior OWIN status
+                    response.StatusCode = initialStatus;
+                    await next(env);
+                }
+            };
+        }
+    }
+}

--- a/src/Startup/Owin/OwinResponseFeature.cs
+++ b/src/Startup/Owin/OwinResponseFeature.cs
@@ -19,6 +19,8 @@ namespace Unravel.Owin
             this.logger = logger;
         }
 
+        public bool AssumeBodyModified { get; private set; }
+
         public int StatusCode
         {
             get => response.StatusCode;
@@ -39,8 +41,8 @@ namespace Unravel.Owin
 
         public Stream Body
         {
-            get => response.Body;
-            set => response.Body = value;
+            get { AssumeBodyModified = true; return response.Body; }
+            set { AssumeBodyModified = true; response.Body = value; }
         }
 
         public bool HasStarted => response.HasStarted;

--- a/src/Startup/Owin/OwinResponseFeature.cs
+++ b/src/Startup/Owin/OwinResponseFeature.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -51,11 +52,55 @@ namespace Unravel.Owin
             response.OnStarting(callback, state);
         }
 
+        private readonly object _onCompletedSync = new object();
+        private Stack<(Func<object, Task>, object)> _onCompleted;
+
+        // From: https://github.com/dotnet/aspnetcore/blob/c2cfc5f140cd2743ecc33eeeb49c5a2dd35b017f/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs#L658-L668
         public void OnCompleted(Func<object, Task> callback, object state)
         {
             logger.LogDebug("OnCompleted {0}.{1}(state)", callback?.Method.DeclaringType.FullName, callback?.Method.Name);
 
-            // TODO: Save/call these
+            lock (_onCompletedSync)
+            {
+                if (_onCompleted == null)
+                {
+                    _onCompleted = new Stack<(Func<object, Task>, object)>();
+                }
+                _onCompleted.Push((callback, state));
+            }
+        }
+
+        // From: https://github.com/dotnet/aspnetcore/blob/c2cfc5f140cd2743ecc33eeeb49c5a2dd35b017f/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs#L732-L762
+        public Task FireOnCompletedAsync()
+        {
+            Stack<(Func<object, Task>, object)> onCompleted;
+            lock (_onCompletedSync)
+            {
+                onCompleted = _onCompleted;
+                _onCompleted = null;
+            }
+
+            if (onCompleted == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            return FireOnCompletedAwaited(onCompleted);
+        }
+
+        private async Task FireOnCompletedAwaited(Stack<(Func<object, Task>, object)> onCompleted)
+        {
+            foreach (var (callback, state) in onCompleted)
+            {
+                try
+                {
+                    await callback(state);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "An unhandled exception was thrown by the application.");
+                }
+            }
         }
     }
 }

--- a/src/Startup/Owin/OwinResponseFeature.cs
+++ b/src/Startup/Owin/OwinResponseFeature.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging;
+
+namespace Unravel.Owin
+{
+    public class OwinResponseFeature : IHttpResponseFeature
+    {
+        private readonly IHttpResponseFeature response;
+        private readonly ILogger logger;
+
+        public OwinResponseFeature(IHttpResponseFeature response, ILogger logger)
+        {
+            this.response = response;
+            this.logger = logger;
+        }
+
+        public int StatusCode
+        {
+            get => response.StatusCode;
+            set => response.StatusCode = value;
+        }
+
+        public string ReasonPhrase
+        {
+            get => response.ReasonPhrase;
+            set => response.ReasonPhrase = value;
+        }
+
+        public IHeaderDictionary Headers
+        {
+            get => response.Headers;
+            set => response.Headers = value;
+        }
+
+        public Stream Body
+        {
+            get => response.Body;
+            set => response.Body = value;
+        }
+
+        public bool HasStarted => response.HasStarted;
+
+        public void OnStarting(Func<object, Task> callback, object state)
+        {
+            logger.LogDebug("OnStarting {0}.{1}(state)", callback?.Method.DeclaringType.FullName, callback?.Method.Name);
+
+            response.OnStarting(callback, state);
+        }
+
+        public void OnCompleted(Func<object, Task> callback, object state)
+        {
+            logger.LogDebug("OnCompleted {0}.{1}(state)", callback?.Method.DeclaringType.FullName, callback?.Method.Name);
+
+            // TODO: Save/call these
+        }
+    }
+}

--- a/src/Startup/Unravel.Startup.csproj
+++ b/src/Startup/Unravel.Startup.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Owin" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.1.1" />


### PR DESCRIPTION
No idea what parts of the ASP.NET Core ecosystem will actually work with this, but it's a start:

1. Add `app.UseAspNetCore()` to the OWIN pipeline.
2. Override `Configure(IApplicationBuilder app)` in a Startup that inherits from `Unravel.Application` (from #2).

All services/config are shared.

![image](https://user-images.githubusercontent.com/133987/137572041-2ca7eea0-ac79-49cc-a354-6fd012d724e6.png)
