### PR TITLE
Add Unravel.AspNetCore.Mvc with `IgnoreControllersOfType<T>()`

### DIFF
--- a/Unravel.sln
+++ b/Unravel.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Unravel.Startup", "src\Star
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Unravel.AspNet.Mvc", "src\AspNet.Mvc\Unravel.AspNet.Mvc.csproj", "{3372BA01-9E2B-48C8-A365-E36141BA32D1}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Unravel.AspNetCore.Mvc", "src\AspNetCore.Mvc\Unravel.AspNetCore.Mvc.csproj", "{D8FDA2DA-EDF4-49BE-90AE-D74763C14DFF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +67,18 @@ Global
 		{3372BA01-9E2B-48C8-A365-E36141BA32D1}.Release|x64.Build.0 = Release|Any CPU
 		{3372BA01-9E2B-48C8-A365-E36141BA32D1}.Release|x86.ActiveCfg = Release|Any CPU
 		{3372BA01-9E2B-48C8-A365-E36141BA32D1}.Release|x86.Build.0 = Release|Any CPU
+		{D8FDA2DA-EDF4-49BE-90AE-D74763C14DFF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8FDA2DA-EDF4-49BE-90AE-D74763C14DFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8FDA2DA-EDF4-49BE-90AE-D74763C14DFF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D8FDA2DA-EDF4-49BE-90AE-D74763C14DFF}.Debug|x64.Build.0 = Debug|Any CPU
+		{D8FDA2DA-EDF4-49BE-90AE-D74763C14DFF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D8FDA2DA-EDF4-49BE-90AE-D74763C14DFF}.Debug|x86.Build.0 = Debug|Any CPU
+		{D8FDA2DA-EDF4-49BE-90AE-D74763C14DFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8FDA2DA-EDF4-49BE-90AE-D74763C14DFF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8FDA2DA-EDF4-49BE-90AE-D74763C14DFF}.Release|x64.ActiveCfg = Release|Any CPU
+		{D8FDA2DA-EDF4-49BE-90AE-D74763C14DFF}.Release|x64.Build.0 = Release|Any CPU
+		{D8FDA2DA-EDF4-49BE-90AE-D74763C14DFF}.Release|x86.ActiveCfg = Release|Any CPU
+		{D8FDA2DA-EDF4-49BE-90AE-D74763C14DFF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/examples/Web/Controllers/AspNetCoreApiController.cs
+++ b/examples/Web/Controllers/AspNetCoreApiController.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+using UnravelExamples.Web.Services;
+
+namespace UnravelExamples.Web.Controllers
+{
+    [ApiController]
+    public class AspNetCoreApiController : Controller
+    {
+        private readonly IServiceProvider services;
+
+        public AspNetCoreApiController(IServiceProvider services)
+        {
+            this.services = services;
+        }
+
+        [HttpGet("[controller]")]
+        public ActionResult Index()
+        {
+            var env = new EnvironmentCheck("ASP.NET Core API Controller Injection", services);
+            return Content(env.ToString(), "application/json; charset=utf-8");
+        }
+    }
+}

--- a/examples/Web/Controllers/AspNetCoreMvcController.cs
+++ b/examples/Web/Controllers/AspNetCoreMvcController.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+using UnravelExamples.Web.Services;
+
+namespace UnravelExamples.Web.Controllers
+{
+    public class AspNetCoreMvcController : Controller
+    {
+        private readonly IServiceProvider services;
+
+        public AspNetCoreMvcController(IServiceProvider services)
+        {
+            this.services = services;
+        }
+
+        public ActionResult Index()
+        {
+            var env = new EnvironmentCheck("ASP.NET Core MVC Controller Injection", services);
+            return Content(env.ToString(), "application/json; charset=utf-8");
+        }
+    }
+}

--- a/examples/Web/Startup.cs
+++ b/examples/Web/Startup.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Owin;
-using Unravel.AspNetCore.Mvc.Internal;
 using UnravelExamples.Web.Services;
 
 namespace UnravelExamples.Web
@@ -18,10 +17,8 @@ namespace UnravelExamples.Web
 
             services.AddHttpContextAccessor();
             services.AddMvc()
+                .IgnoreControllersOfType<System.Web.Mvc.IController>()
                 ;
-
-            // TODO: Move to IMvcBuilder with better name?
-            services.AddIgnoreControllersOfTypeActionInvokerProvider<System.Web.Mvc.IController>();
         }
 
         public override void ConfigureOwin(IAppBuilder app)

--- a/examples/Web/Startup.cs
+++ b/examples/Web/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Owin;
+using Unravel.AspNetCore.Mvc.Internal;
 using UnravelExamples.Web.Services;
 
 namespace UnravelExamples.Web
@@ -18,6 +19,9 @@ namespace UnravelExamples.Web
             services.AddHttpContextAccessor();
             services.AddMvc()
                 ;
+
+            // TODO: Move to IMvcBuilder with better name?
+            services.AddIgnoreControllersOfTypeActionInvokerProvider<System.Web.Mvc.IController>();
         }
 
         public override void ConfigureOwin(IAppBuilder app)

--- a/examples/Web/Startup.cs
+++ b/examples/Web/Startup.cs
@@ -16,6 +16,8 @@ namespace UnravelExamples.Web
                 ;
 
             services.AddHttpContextAccessor();
+            services.AddMvc()
+                ;
         }
 
         public override void ConfigureOwin(IAppBuilder app)
@@ -30,6 +32,8 @@ namespace UnravelExamples.Web
         public override void Configure(IApplicationBuilder app)
         {
             app.Map("/AspNetCore", AspNetCoreTestRoutes);
+
+            app.UseMvcWithDefaultRoute();
         }
     }
 }

--- a/examples/Web/UnravelExamples.Web.csproj
+++ b/examples/Web/UnravelExamples.Web.csproj
@@ -538,6 +538,8 @@
     <Compile Include="App_Start\FilterConfig.cs" />
     <Compile Include="App_Start\RouteConfig.cs" />
     <Compile Include="App_Start\WebApiConfig.cs" />
+    <Compile Include="Controllers\AspNetCoreApiController.cs" />
+    <Compile Include="Controllers\AspNetCoreMvcController.cs" />
     <Compile Include="Controllers\AspNetTestController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
     <Compile Include="Global.asax.cs">

--- a/examples/Web/UnravelExamples.Web.csproj
+++ b/examples/Web/UnravelExamples.Web.csproj
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.props" Condition="Exists('..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.props')" />
+  <Import Project="..\..\packages\Microsoft.DiaSymReader.Native.1.7.0\build\Microsoft.DiaSymReader.Native.props" Condition="Exists('..\..\packages\Microsoft.DiaSymReader.Native.1.7.0\build\Microsoft.DiaSymReader.Native.props')" />
+  <Import Project="..\..\packages\Microsoft.AspNetCore.Razor.Design.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Razor.Design.props" Condition="Exists('..\..\packages\Microsoft.AspNetCore.Razor.Design.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Razor.Design.props')" />
   <Import Project="..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.props" Condition="Exists('..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -46,6 +49,36 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.Antiforgery, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Antiforgery.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Antiforgery.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Authentication.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Authentication.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Authentication.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Authentication.Core, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Authentication.Core.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Authentication.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Authorization, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Authorization.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Authorization.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Authorization.Policy, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Authorization.Policy.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Authorization.Policy.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Cors, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Cors.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Cors.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Cryptography.Internal, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Cryptography.Internal.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Cryptography.Internal.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.DataProtection, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.DataProtection.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.DataProtection.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.DataProtection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.DataProtection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.DataProtection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Diagnostics.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Diagnostics.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Diagnostics.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.AspNetCore.Hosting, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Hosting.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Hosting.dll</HintPath>
     </Reference>
@@ -54,6 +87,9 @@
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Hosting.Server.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Hosting.Server.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Html.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Html.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Html.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Http, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Http.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Http.dll</HintPath>
@@ -67,13 +103,94 @@
     <Reference Include="Microsoft.AspNetCore.Http.Features, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Http.Features.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Http.Features.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.AspNetCore.JsonPatch, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.JsonPatch.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.JsonPatch.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Localization, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Localization.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Localization.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Mvc, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Mvc.Abstractions, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Abstractions.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Mvc.ApiExplorer, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.ApiExplorer.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.ApiExplorer.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Mvc.Core, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Core.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Mvc.Cors, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Cors.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.Cors.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Mvc.DataAnnotations, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.DataAnnotations.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.DataAnnotations.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Mvc.Formatters.Json, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Formatters.Json.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.Formatters.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Mvc.Localization, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Localization.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.Localization.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Mvc.Razor, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Razor.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\lib\net46\Microsoft.AspNetCore.Mvc.Razor.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Mvc.RazorPages, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.RazorPages.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.RazorPages.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Mvc.TagHelpers, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.TagHelpers.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.TagHelpers.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Mvc.ViewFeatures, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.ViewFeatures.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.ViewFeatures.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Razor, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Razor.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Razor.Language, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Razor.Language.2.1.1\lib\net46\Microsoft.AspNetCore.Razor.Language.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Razor.Runtime, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Razor.Runtime.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Razor.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.ResponseCaching.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.ResponseCaching.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.ResponseCaching.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Routing, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Routing.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Routing.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Routing.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Routing.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Routing.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.AspNetCore.WebUtilities, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.WebUtilities.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.WebUtilities.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.8.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.2.8.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Razor, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Razor.2.1.1\lib\net46\Microsoft.CodeAnalysis.Razor.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.DotNet.PlatformAbstractions.2.1.0\lib\net45\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Caching.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Caching.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Caching.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Caching.Memory, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Caching.Memory.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Caching.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Extensions.Configuration, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Configuration.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll</HintPath>
     </Reference>
@@ -101,8 +218,14 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyModel, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyModel.2.1.0\lib\net451\Microsoft.Extensions.DependencyModel.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.FileProviders.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileProviders.Composite, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.FileProviders.Composite.2.1.1\lib\netstandard2.0\Microsoft.Extensions.FileProviders.Composite.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.FileProviders.Physical, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.FileProviders.Physical.2.1.1\lib\netstandard2.0\Microsoft.Extensions.FileProviders.Physical.dll</HintPath>
@@ -112,6 +235,12 @@
     </Reference>
     <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Hosting.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Localization, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Localization.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Localization.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Localization.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Localization.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Localization.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Logging, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
@@ -137,6 +266,9 @@
     <Reference Include="Microsoft.Extensions.Primitives, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Primitives.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.WebEncoders, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.WebEncoders.2.1.1\lib\netstandard2.0\Microsoft.Extensions.WebEncoders.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Net.Http.Headers, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Net.Http.Headers.2.1.1\lib\netstandard2.0\Microsoft.Net.Http.Headers.dll</HintPath>
     </Reference>
@@ -146,28 +278,90 @@
     <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Owin.Host.SystemWeb.4.2.0\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Win32.Registry, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Win32.Registry.4.5.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json.Bson, Version=1.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.Bson.1.0.1\lib\net45\Newtonsoft.Json.Bson.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.AppContext.4.3.0\lib\net463\System.AppContext.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
     </Reference>
+    <Reference Include="System.ComponentModel.Annotations, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ComponentModel.Annotations.4.5.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Data" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Data.OracleClient" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Diagnostics.FileVersionInfo, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.FileVersionInfo.4.3.0\lib\net46\System.Diagnostics.FileVersionInfo.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Diagnostics.StackTrace, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.StackTrace.4.3.0\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Linq, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Linq.4.3.0\lib\net463\System.Linq.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Linq.Expressions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Linq.Expressions.4.3.0\lib\net463\System.Linq.Expressions.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Memory.4.5.1\lib\netstandard2.0\System.Memory.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
@@ -175,14 +369,90 @@
     <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
+    <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Reflection.Metadata, Version=1.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reflection.Metadata.1.6.0\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.1\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.Extensions.4.3.0\lib\net462\System.Runtime.Extensions.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.4.3.0\lib\net463\System.Runtime.InteropServices.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security" />
+    <Reference Include="System.Security.AccessControl, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.AccessControl.4.5.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Xml, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Xml.4.5.0\lib\net461\System.Security.Cryptography.Xml.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Permissions, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Permissions.4.5.0\lib\net461\System.Security.Permissions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Principal.Windows.4.5.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Text.Encoding.CodePages, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Text.Encoding.CodePages.4.3.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
+    </Reference>
     <Reference Include="System.Text.Encodings.Web, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Text.Encodings.Web.4.5.0\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
@@ -233,6 +503,26 @@
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\..\packages\Microsoft.AspNet.Razor.3.2.7\lib\net45\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.XmlDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Xml.XmlDocument.4.3.0\lib\net46\System.Xml.XmlDocument.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.XPath, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Xml.XPath.4.3.0\lib\net46\System.Xml.XPath.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.XPath.XDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Xml.XPath.XDocument.4.3.0\lib\net46\System.Xml.XPath.XDocument.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="WebGrease">
       <Private>True</Private>
@@ -287,6 +577,7 @@
   <ItemGroup>
     <Folder Include="App_Data\" />
     <Folder Include="Models\" />
+    <Folder Include="Views\AspNetCoreTest\" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -301,6 +592,10 @@
       <Project>{06797441-1726-4bd0-a74d-21e211756367}</Project>
       <Name>Unravel.Startup</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -345,8 +640,13 @@
     <Error Condition="!Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.AspNetCore.Razor.Design.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Razor.Design.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.AspNetCore.Razor.Design.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Razor.Design.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.DiaSymReader.Native.1.7.0\build\Microsoft.DiaSymReader.Native.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.DiaSymReader.Native.1.7.0\build\Microsoft.DiaSymReader.Native.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.targets'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.targets" Condition="Exists('..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.targets')" />
+  <Import Project="..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.targets" Condition="Exists('..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/examples/Web/UnravelExamples.Web.csproj
+++ b/examples/Web/UnravelExamples.Web.csproj
@@ -590,6 +590,10 @@
       <Project>{3372ba01-9e2b-48c8-a365-e36141ba32d1}</Project>
       <Name>Unravel.AspNet.Mvc</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\AspNetCore.Mvc\Unravel.AspNetCore.Mvc.csproj">
+      <Project>{d8fda2da-edf4-49be-90ae-d74763c14dff}</Project>
+      <Name>Unravel.AspNetCore.Mvc</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\Startup\Unravel.Startup.csproj">
       <Project>{06797441-1726-4bd0-a74d-21e211756367}</Project>
       <Name>Unravel.Startup</Name>

--- a/examples/Web/Views/Home/Index.cshtml
+++ b/examples/Web/Views/Home/Index.cshtml
@@ -28,6 +28,8 @@
         <li><a target="env" href="/AspNetCore/IApplicationBuilder_ApplicationServices"><code>IApplicationBuilder.ApplicationServices</code></a></li>
         <li><a target="env" href="/AspNetCore/HttpContext_RequestServices"><code>HttpContext.RequestServices</code></a></li>
         <li><a target="env" href="/AspNetCore/Throw"><code>throw</code></a></li>
+        <li><a target="env" href="@Url.Action(nameof(AspNetCoreApiController.Index), "AspNetCoreApi")">API Controller Constructor Injection</a></li>
+        <li><a target="env" href="@Url.Action(nameof(AspNetCoreMvcController.Index), "AspNetCoreMvc")">MVC Controller Constructor Injection</a></li>
     </ul>
 
     <h2>OWIN after <code>UseAspNetCore()</code></h2>

--- a/examples/Web/Web.config
+++ b/examples/Web/Web.config
@@ -11,7 +11,11 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
   </appSettings>
   <system.web>
-    <compilation debug="true" targetFramework="4.7.2" />
+    <compilation debug="true" targetFramework="4.7.2">
+      <assemblies>
+        <add assembly="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51" />
+      </assemblies>
+    </compilation>
     <httpRuntime targetFramework="4.7.2" />
   </system.web>
   <system.webServer>

--- a/examples/Web/Web.config
+++ b/examples/Web/Web.config
@@ -57,8 +57,20 @@
         <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.1" newVersion="4.0.3.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ComponentModel.Annotations" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.4.3.0" newVersion="1.4.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.3.0" newVersion="1.2.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/examples/Web/packages.config
+++ b/examples/Web/packages.config
@@ -9,15 +9,57 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Antiforgery" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Authentication.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Authentication.Core" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Authorization" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Authorization.Policy" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Cors" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Cryptography.Internal" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.DataProtection" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.DataProtection.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Diagnostics.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Hosting" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Hosting.Server.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Html.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Http" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Http.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Http.Extensions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Http.Features" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.JsonPatch" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Localization" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc" version="2.1.3" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Abstractions" version="2.1.3" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.ApiExplorer" version="2.1.3" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Core" version="2.1.3" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Cors" version="2.1.3" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.DataAnnotations" version="2.1.3" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Formatters.Json" version="2.1.3" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Localization" version="2.1.3" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Razor" version="2.1.3" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Razor.Extensions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.RazorPages" version="2.1.3" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.TagHelpers" version="2.1.3" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.ViewFeatures" version="2.1.3" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Razor" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Razor.Design" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Razor.Language" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Razor.Runtime" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.ResponseCaching.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Routing" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Routing.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.WebUtilities" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net472" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.8.0" targetFramework="net472" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.8.0" targetFramework="net472" />
+  <package id="Microsoft.CodeAnalysis.Razor" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="3.6.0" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
+  <package id="Microsoft.DiaSymReader.Native" version="1.7.0" targetFramework="net472" />
+  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.1.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Caching.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Caching.Memory" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.Configuration" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.Configuration.Binder" version="2.1.1" targetFramework="net472" />
@@ -27,10 +69,14 @@
   <package id="Microsoft.Extensions.Configuration.UserSecrets" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyModel" version="2.1.0" targetFramework="net472" />
   <package id="Microsoft.Extensions.FileProviders.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.FileProviders.Composite" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.FileProviders.Physical" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.FileSystemGlobbing" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.Hosting.Abstractions" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Localization" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Localization.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.Logging" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.Logging.Configuration" version="2.1.1" targetFramework="net472" />
@@ -39,19 +85,68 @@
   <package id="Microsoft.Extensions.Options" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Extensions.Primitives" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.WebEncoders" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Net.Http.Headers" version="2.1.1" targetFramework="net472" />
   <package id="Microsoft.Owin" version="4.2.0" targetFramework="net472" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="4.2.0" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
+  <package id="Microsoft.Win32.Registry" version="4.5.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
+  <package id="Newtonsoft.Json.Bson" version="1.0.1" targetFramework="net472" />
   <package id="Owin" version="1.0" targetFramework="net472" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net472" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net472" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net472" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net472" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net472" />
+  <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net472" />
+  <package id="System.Console" version="4.3.0" targetFramework="net472" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net472" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net472" />
+  <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net472" />
+  <package id="System.Diagnostics.StackTrace" version="4.3.0" targetFramework="net472" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net472" />
+  <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net472" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net472" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net472" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net472" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net472" />
   <package id="System.Memory" version="4.5.1" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net472" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net472" />
   <package id="System.Reflection.Metadata" version="1.6.0" targetFramework="net472" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" targetFramework="net472" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.AccessControl" version="4.5.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Xml" version="4.5.0" targetFramework="net472" />
+  <package id="System.Security.Permissions" version="4.5.0" targetFramework="net472" />
+  <package id="System.Security.Principal.Windows" version="4.5.0" targetFramework="net472" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net472" />
+  <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net472" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net472" />
   <package id="System.Text.Encodings.Web" version="4.5.0" targetFramework="net472" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net472" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net472" />
+  <package id="System.Threading.Thread" version="4.3.0" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net472" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net472" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net472" />
+  <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net472" />
+  <package id="System.Xml.XPath" version="4.3.0" targetFramework="net472" />
+  <package id="System.Xml.XPath.XDocument" version="4.3.0" targetFramework="net472" />
   <package id="WebGrease" version="1.6.0" targetFramework="net472" />
 </packages>

--- a/src/AspNetCore.Mvc/DependencyInjection/UnravelAspNetCoreMvcBuilderExtensions.cs
+++ b/src/AspNetCore.Mvc/DependencyInjection/UnravelAspNetCoreMvcBuilderExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Unravel.AspNetCore.Mvc.Internal;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    ///   Extensions for configuring MVC using an <see cref="IMvcBuilder"/>.
+    /// </summary>
+    public static class UnravelAspNetCoreMvcBuilderExtensions
+    {
+        /// <summary>
+        ///   Configures ASP.NET Core to not handle controllers assignable from <typeparamref name="TController"/>,
+        ///   e.g. <c>System.Web.Mvc.Controller</c> or <c>System.Web.Http.ApiController</c>.
+        /// </summary>
+        /// <typeparam name="TController">The controller base type to ignore.</typeparam>
+        /// <returns>The <see cref="IMvcBuilder"/>.</returns>
+        public static void IgnoreControllersOfType<TController>(this IMvcBuilder builder)
+        {
+            builder.Services.AddIgnoreControllersOfTypeActionInvokerProvider<TController>();
+        }
+    }
+}

--- a/src/AspNetCore.Mvc/DependencyInjection/UnravelAspNetCoreMvcCoreBuilderExtensions.cs
+++ b/src/AspNetCore.Mvc/DependencyInjection/UnravelAspNetCoreMvcCoreBuilderExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Unravel.AspNetCore.Mvc.Internal;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    ///   Extensions for configuring MVC using an <see cref="IMvcCoreBuilder"/>.
+    /// </summary>
+    public static class UnravelAspNetCoreMvcCoreBuilderExtensions
+    {
+        /// <summary>
+        ///   Configures ASP.NET Core to not handle controllers assignable from <typeparamref name="TController"/>,
+        ///   e.g. <c>System.Web.Mvc.Controller</c> or <c>System.Web.Http.ApiController</c>.
+        /// </summary>
+        /// <typeparam name="TController">The controller base type to ignore.</typeparam>
+        /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
+        public static void IgnoreControllersOfType<TController>(this IMvcCoreBuilder builder)
+        {
+            builder.Services.AddIgnoreControllersOfTypeActionInvokerProvider<TController>();
+        }
+    }
+}

--- a/src/AspNetCore.Mvc/Internal/IgnoreControllersOfTypeActionInvokerProvider.cs
+++ b/src/AspNetCore.Mvc/Internal/IgnoreControllersOfTypeActionInvokerProvider.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+
+namespace Unravel.AspNetCore.Mvc.Internal
+{
+
+    public class IgnoreControllersOfTypeActionInvokerProvider<TController> : IActionInvokerProvider
+    {
+        /// <summary>
+        ///   Gets the order value for determining the order of execution of providers.
+        ///   Returns -995, to execute shortly after <see cref="Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvokerProvider"/> (-1000).
+        /// </summary>
+        public virtual int Order => -995;
+
+        /// <summary>
+        ///   Intercepts <see cref="ControllerActionDescriptor"/> for <typeparamref name="TController"/>.
+        /// </summary>
+        /// <param name="context">The <see cref="ActionInvokerProviderContext"/>.</param>
+        public void OnProvidersExecuting(ActionInvokerProviderContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (context.ActionContext.ActionDescriptor is ControllerActionDescriptor controllerActionDescriptor)
+            {
+                var controllerTypeInfo = controllerActionDescriptor.ControllerTypeInfo;
+                if (typeof(TController).GetTypeInfo().IsAssignableFrom(controllerTypeInfo))
+                {
+                    context.Result = new NotFoundActionInvoker(context.ActionContext);
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public void OnProvidersExecuted(ActionInvokerProviderContext context)
+        {
+        }
+
+        private class NotFoundActionInvoker : IActionInvoker
+        {
+            private readonly ActionContext actionContext;
+
+            public NotFoundActionInvoker(ActionContext actionContext)
+            {
+                this.actionContext = actionContext;
+            }
+
+            public Task InvokeAsync()
+            {
+                actionContext.HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/AspNetCore.Mvc/Internal/UnravelAspNetCoreMvcServiceCollectionExtensions.cs
+++ b/src/AspNetCore.Mvc/Internal/UnravelAspNetCoreMvcServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Unravel.AspNetCore.Mvc.Internal
+{
+    /// <summary>
+    ///   Extension methods for setting up ASP.NET Core MVC services in an <see cref="IServiceCollection" />.
+    /// </summary>
+    public static class UnravelAspNetCoreMvcServiceCollectionExtensions
+    {
+        public static void AddIgnoreControllersOfTypeActionInvokerProvider<T>(this IServiceCollection services)
+        {
+            services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<IActionInvokerProvider, IgnoreControllersOfTypeActionInvokerProvider<T>>());
+        }
+    }
+}

--- a/src/AspNetCore.Mvc/Unravel.AspNetCore.Mvc.csproj
+++ b/src/AspNetCore.Mvc/Unravel.AspNetCore.Mvc.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.3" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Startup\Unravel.Startup.csproj" />
   </ItemGroup>
 

--- a/src/AspNetCore.Mvc/Unravel.AspNetCore.Mvc.csproj
+++ b/src/AspNetCore.Mvc/Unravel.AspNetCore.Mvc.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <AssemblyName>Unravel.AspNetCore.Mvc</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Startup\Unravel.Startup.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Basic ASP.NET Core MVC seems to work with #4, but it tries to handle ASP.NET MVC controllers, too. An [`IActionInvokerProvider`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.abstractions.iactioninvokerprovider?view=aspnetcore-2.1) seems to be the right hook to intercept and "handle" (`Response.StatusCode` = 404) those so they fall back through to ASP.NET MVC. Hoping this approach will work for ASP.NET WebApi controllers, too.

I'm trying to keep the projects carefully partitioned to let folks manage their dependencies. You shouldn't need to install `Microsoft.AspNetCore.Mvc` just to get the hosting environment, so this uses a separate **Unravel.AspNetCore.Mvc** project.

### Usage

1. Register services and ignore legacy controllers in `ConfigureServices()`:

    ```csharp
    services.AddMvc()
        .IgnoreControllersOfType<System.Web.Mvc.IController>()
        ....;
    ```
2. Add MVC to the Core pipeline in `Configure(IApplicationBuilder app)`, e.g.

    ```csharp
    app.UseMvcWithDefaultRoute();
    ```
