### PR TITLE
Add Unravel.AspNet.WebApi with Dependency Resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ We'll see how close we can get…
 
 ## Unravel.AspNet.Mvc
 
-Similar to ASP.NET Core 2.1's [`AddMvc()`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.mvcservicecollectionextensions.addmvc?view=aspnetcore-2.1), Unravel provides an `AddAspNetMvc()` extension method on `IServiceCollection` that registers an `IDependencyResolver`.
+Similar to ASP.NET Core 2.1's [`AddMvc()`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.mvcservicecollectionextensions.addmvc?view=aspnetcore-2.1), Unravel provides an `AddAspNetMvc()` extension method on `IServiceCollection` that registers a `System.Web.Mvc.IDependencyResolver`.
 
 The resulting `IAspNetMvcBuilder` is similar to [`IMvcBuilder`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.imvcbuilder?view=aspnetcore-2.1), providing an extension point for additional configuration:
 
@@ -90,6 +90,22 @@ The resulting `IAspNetMvcBuilder` is similar to [`IMvcBuilder`](https://docs.mic
 public override void ConfigureServices(IServiceCollection services)
 {
     services.AddAspNetMvc()
+        .AddControllersAsServices();
+}
+```
+
+## Unravel.AspNet.WebApi
+
+Similar to `AddAspNetMvc()` described above, there's also an `AddAspNetWebApi()` extension method on `IServiceCollection` that registers a `System.Web.Http.Dependencies.IDependencyResolver`.
+
+The resulting `IAspNetWebApiBuilder` is similar to [`IMvcBuilder`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.imvcbuilder?view=aspnetcore-2.1), providing an extension point for additional configuration:
+
+- [`AddControllersAsServices()`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.mvccoremvcbuilderextensions.addcontrollersasservices?view=aspnetcore-2.1)
+
+```csharp
+public override void ConfigureServices(IServiceCollection services)
+{
+    services.AddAspNetWebApi()
         .AddControllersAsServices();
 }
 ```

--- a/Unravel.sln
+++ b/Unravel.sln
@@ -21,6 +21,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Unravel.AspNet.Mvc", "src\A
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Unravel.AspNetCore.Mvc", "src\AspNetCore.Mvc\Unravel.AspNetCore.Mvc.csproj", "{D8FDA2DA-EDF4-49BE-90AE-D74763C14DFF}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Unravel.AspNet.WebApi", "src\AspNet.WebApi\Unravel.AspNet.WebApi.csproj", "{22478CEE-818D-455C-9AE1-D9BB1C9B91A9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -79,6 +81,18 @@ Global
 		{D8FDA2DA-EDF4-49BE-90AE-D74763C14DFF}.Release|x64.Build.0 = Release|Any CPU
 		{D8FDA2DA-EDF4-49BE-90AE-D74763C14DFF}.Release|x86.ActiveCfg = Release|Any CPU
 		{D8FDA2DA-EDF4-49BE-90AE-D74763C14DFF}.Release|x86.Build.0 = Release|Any CPU
+		{22478CEE-818D-455C-9AE1-D9BB1C9B91A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22478CEE-818D-455C-9AE1-D9BB1C9B91A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22478CEE-818D-455C-9AE1-D9BB1C9B91A9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{22478CEE-818D-455C-9AE1-D9BB1C9B91A9}.Debug|x64.Build.0 = Debug|Any CPU
+		{22478CEE-818D-455C-9AE1-D9BB1C9B91A9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{22478CEE-818D-455C-9AE1-D9BB1C9B91A9}.Debug|x86.Build.0 = Debug|Any CPU
+		{22478CEE-818D-455C-9AE1-D9BB1C9B91A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22478CEE-818D-455C-9AE1-D9BB1C9B91A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22478CEE-818D-455C-9AE1-D9BB1C9B91A9}.Release|x64.ActiveCfg = Release|Any CPU
+		{22478CEE-818D-455C-9AE1-D9BB1C9B91A9}.Release|x64.Build.0 = Release|Any CPU
+		{22478CEE-818D-455C-9AE1-D9BB1C9B91A9}.Release|x86.ActiveCfg = Release|Any CPU
+		{22478CEE-818D-455C-9AE1-D9BB1C9B91A9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/examples/Web/Controllers/AspNetCoreApiController.cs
+++ b/examples/Web/Controllers/AspNetCoreApiController.cs
@@ -20,5 +20,11 @@ namespace UnravelExamples.Web.Controllers
             var env = new EnvironmentCheck("ASP.NET Core API Controller Injection", services);
             return Content(env.ToString(), "application/json; charset=utf-8");
         }
+
+        [HttpGet("[controller]/[action]")]
+        public ActionResult Throw()
+        {
+            throw new ApplicationException("From ASP.NET Core API Controller");
+        }
     }
 }

--- a/examples/Web/Controllers/AspNetCoreMvcController.cs
+++ b/examples/Web/Controllers/AspNetCoreMvcController.cs
@@ -18,5 +18,10 @@ namespace UnravelExamples.Web.Controllers
             var env = new EnvironmentCheck("ASP.NET Core MVC Controller Injection", services);
             return Content(env.ToString(), "application/json; charset=utf-8");
         }
+
+        public ActionResult Throw()
+        {
+            throw new ApplicationException("From ASP.NET Core MVC Controller");
+        }
     }
 }

--- a/examples/Web/Controllers/AspNetMvcController.cs
+++ b/examples/Web/Controllers/AspNetMvcController.cs
@@ -1,23 +1,21 @@
 ﻿using System;
-using System.Web;
 using System.Web.Mvc;
-using Unravel;
 using UnravelExamples.Web.Services;
 
 namespace UnravelExamples.Web.Controllers
 {
-    public class AspNetTestController : Controller
+    public class AspNetMvcController : Controller
     {
         private readonly IServiceProvider services;
 
-        public AspNetTestController(IServiceProvider services)
+        public AspNetMvcController(IServiceProvider services)
         {
             this.services = services;
         }
 
         public ActionResult Index()
         {
-            var env = new EnvironmentCheck("ASP.NET Controller Injection", services);
+            var env = new EnvironmentCheck("ASP.NET MVC Controller Injection", services);
             return Content(env.ToString(), "application/json; charset=utf-8");
         }
     }

--- a/examples/Web/Controllers/AspNetWebApiController.cs
+++ b/examples/Web/Controllers/AspNetWebApiController.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Web.Http;
+using UnravelExamples.Web.Services;
+
+namespace UnravelExamples.Web.Controllers
+{
+    public class AspNetWebApiController : ApiController
+    {
+        private readonly IServiceProvider services;
+
+        public AspNetWebApiController(IServiceProvider services)
+        {
+            this.services = services;
+        }
+
+        [HttpGet]
+        [Route("AspNetWebApi")]
+        public IHttpActionResult Index()
+        {
+            var env = new EnvironmentCheck("ASP.NET Core API Controller Injection", services);
+            var response = Request.CreateResponse(HttpStatusCode.OK);
+            response.Content = new StringContent(env.ToString(), Encoding.UTF8, "application/json");
+            return ResponseMessage(response);
+        }
+
+        [HttpGet]
+        [Route("AspNetWebApi/Throw")]
+        public IHttpActionResult Throw()
+        {
+            throw new ApplicationException("From ASP.NET Core API Controller");
+        }
+    }
+}

--- a/examples/Web/Services/EnvironmentCheck.cs
+++ b/examples/Web/Services/EnvironmentCheck.cs
@@ -22,6 +22,7 @@ namespace UnravelExamples.Web.Services
             var json = new JObject
             {
                 { nameof(Title), Title },
+                { nameof(IServiceProvider), Services == null ? null : "(object)" },
             };
 
             foreach (var environment in GetEnvironments())
@@ -32,6 +33,9 @@ namespace UnravelExamples.Web.Services
 
         public IEnumerable<EnvironmentBase> GetEnvironments()
         {
+            if (Services == null)
+                yield break;
+
             yield return new EnvironmentHosting(Services);
             yield return Services.GetService<Counters>();
 

--- a/examples/Web/Startup.cs
+++ b/examples/Web/Startup.cs
@@ -15,9 +15,14 @@ namespace UnravelExamples.Web
                 .AddControllersAsServices()
                 ;
 
+            services.AddAspNetWebApi()
+                .AddControllersAsServices()
+                ;
+
             services.AddHttpContextAccessor();
             services.AddMvc()
                 .IgnoreControllersOfType<System.Web.Mvc.IController>()
+                .IgnoreControllersOfType<System.Web.Http.Controllers.IHttpController>()
                 ;
         }
 

--- a/examples/Web/UnravelExamples.Web.csproj
+++ b/examples/Web/UnravelExamples.Web.csproj
@@ -540,7 +540,7 @@
     <Compile Include="App_Start\WebApiConfig.cs" />
     <Compile Include="Controllers\AspNetCoreApiController.cs" />
     <Compile Include="Controllers\AspNetCoreMvcController.cs" />
-    <Compile Include="Controllers\AspNetTestController.cs" />
+    <Compile Include="Controllers\AspNetMvcController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>

--- a/examples/Web/UnravelExamples.Web.csproj
+++ b/examples/Web/UnravelExamples.Web.csproj
@@ -538,6 +538,7 @@
     <Compile Include="App_Start\FilterConfig.cs" />
     <Compile Include="App_Start\RouteConfig.cs" />
     <Compile Include="App_Start\WebApiConfig.cs" />
+    <Compile Include="Controllers\AspNetWebApiController.cs" />
     <Compile Include="Controllers\AspNetCoreApiController.cs" />
     <Compile Include="Controllers\AspNetCoreMvcController.cs" />
     <Compile Include="Controllers\AspNetMvcController.cs" />

--- a/examples/Web/UnravelExamples.Web.csproj
+++ b/examples/Web/UnravelExamples.Web.csproj
@@ -590,6 +590,10 @@
       <Project>{3372ba01-9e2b-48c8-a365-e36141ba32d1}</Project>
       <Name>Unravel.AspNet.Mvc</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\AspNet.WebApi\Unravel.AspNet.WebApi.csproj">
+      <Project>{22478cee-818d-455c-9ae1-d9bb1c9b91a9}</Project>
+      <Name>Unravel.AspNet.WebApi</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\AspNetCore.Mvc\Unravel.AspNetCore.Mvc.csproj">
       <Project>{d8fda2da-edf4-49be-90ae-d74763c14dff}</Project>
       <Name>Unravel.AspNetCore.Mvc</Name>

--- a/examples/Web/Views/Home/Index.cshtml
+++ b/examples/Web/Views/Home/Index.cshtml
@@ -29,7 +29,9 @@
         <li><a target="env" href="/AspNetCore/HttpContext_RequestServices"><code>HttpContext.RequestServices</code></a></li>
         <li><a target="env" href="/AspNetCore/Throw"><code>throw</code></a></li>
         <li><a target="env" href="@Url.Action(nameof(AspNetCoreApiController.Index), "AspNetCoreApi")">API Controller Constructor Injection</a></li>
+        <li><a target="env" href="@Url.Action(nameof(AspNetCoreApiController.Throw), "AspNetCoreApi")">API Controller <code>throw</code></a></li>
         <li><a target="env" href="@Url.Action(nameof(AspNetCoreMvcController.Index), "AspNetCoreMvc")">MVC Controller Constructor Injection</a></li>
+        <li><a target="env" href="@Url.Action(nameof(AspNetCoreMvcController.Throw), "AspNetCoreMvc")">MVC Controller <code>throw</code></a></li>
     </ul>
 
     <h2>OWIN after <code>UseAspNetCore()</code></h2>

--- a/examples/Web/Views/Home/Index.cshtml
+++ b/examples/Web/Views/Home/Index.cshtml
@@ -14,6 +14,12 @@
         <li><a target="env" href="@Url.Action(nameof(AspNetMvcController.Index), "AspNetMvc")">Constructor Injection</a></li>
     </ul>
 
+    <h2>ASP.NET WebApi</h2>
+    <ul>
+        <li><a target="env" href="~/AspNetWebApi">Constructor Injection</a></li>
+        <li><a target="env" href="~/AspNetWebApi/Throw">Constructor Injection <code>throw</code></a></li>
+    </ul>
+
     <h2>OWIN</h2>
     <ul>
         <li><a target="env" href="/OWIN/Startup_Services"><code>Startup.Services</code></a></li>

--- a/examples/Web/Views/Home/Index.cshtml
+++ b/examples/Web/Views/Home/Index.cshtml
@@ -11,7 +11,7 @@
         <li><a target="env" href="@Url.Action(nameof(HomeController.HttpContext_Current_GetRequestServices))"><code>HttpContext.GetRequestServices()</code></a></li>
         <li><a target="env" href="@Url.Action(nameof(HomeController.HttpContextBase_GetRequestServices))"><code>HttpContextBase.GetRequestServices()</code></a></li>
         <li><a target="env" href="@Url.Action(nameof(HomeController.Throw))"><code>throw</code></a></li>
-        <li><a target="env" href="@Url.Action(nameof(AspNetTestController.Index), "AspNetTest")">Constructor Injection</a></li>
+        <li><a target="env" href="@Url.Action(nameof(AspNetMvcController.Index), "AspNetMvc")">Constructor Injection</a></li>
     </ul>
 
     <h2>OWIN</h2>

--- a/src/AspNet.WebApi/DependencyInjection/IAspNetWebApiBuilder.cs
+++ b/src/AspNet.WebApi/DependencyInjection/IAspNetWebApiBuilder.cs
@@ -1,0 +1,13 @@
+﻿namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    ///   An interface for configuring ASP.NET Web API services.
+    /// </summary>
+    public interface IAspNetWebApiBuilder
+    {
+        /// <summary>
+        ///   Gets the <see cref="IServiceCollection"/> where ASP.NET Web API services are configured.
+        /// </summary>
+        IServiceCollection Services { get; }
+    }
+}

--- a/src/AspNet.WebApi/DependencyInjection/Internal/AspNetWebApiBuilder.cs
+++ b/src/AspNet.WebApi/DependencyInjection/Internal/AspNetWebApiBuilder.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Unravel.AspNet.WebApi.DependencyInjection.Internal
+{
+    /// <summary>
+    ///   Allows fine grained configuration of ASP.NET Web API services.
+    /// </summary>
+    public class AspNetWebApiBuilder : IAspNetWebApiBuilder
+    {
+        /// <summary>
+        ///   Initializes a new <see cref="AspNetWebApiBuilder"/> instance.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        public AspNetWebApiBuilder(IServiceCollection services)
+        {
+            Services = services;
+        }
+
+        /// <inheritdoc/>
+        public IServiceCollection Services { get; }
+    }
+}

--- a/src/AspNet.WebApi/DependencyInjection/Internal/GlobalConfigurationStartupFilter.cs
+++ b/src/AspNet.WebApi/DependencyInjection/Internal/GlobalConfigurationStartupFilter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Web.Http;
+using System.Web.Http.Dependencies;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Unravel.AspNet.WebApi.DependencyInjection.Internal
+{
+    public class GlobalConfigurationStartupFilter : IStartupFilter
+    {
+        /// <summary>
+        ///   Updates <see cref="GlobalConfiguration.Configuration"/> from
+        ///   <see cref="IApplicationBuilder.ApplicationServices"/>, if available:
+        ///   <list type="bullet">
+        ///     <item><see cref="HttpConfiguration.DependencyResolver"/></item>
+        ///   </list>
+        /// </summary>
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+        {
+            return UpdateGlobalConfiguration;
+
+            void UpdateGlobalConfiguration(IApplicationBuilder builder)
+            {
+                var config = GlobalConfiguration.Configuration;
+
+                var resolver = builder.ApplicationServices.GetService<IDependencyResolver>();
+                if (resolver != null)
+                    config.DependencyResolver = resolver;
+
+                next(builder);
+            }
+        }
+    }
+}

--- a/src/AspNet.WebApi/DependencyInjection/Internal/ServiceProviderDependencyResolver.cs
+++ b/src/AspNet.WebApi/DependencyInjection/Internal/ServiceProviderDependencyResolver.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Web;
+using System.Web.Http.Dependencies;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Unravel.AspNet.WebApi.DependencyInjection.Internal
+{
+    public sealed class ServiceProviderDependencyResolver : IDependencyResolver
+    {
+        /// <inheritdoc/>
+        public object GetService(Type serviceType) =>
+            HttpContext.Current.GetRequestServices()
+                .GetService(serviceType);
+
+        /// <inheritdoc/>
+        public IEnumerable<object> GetServices(Type serviceType) =>
+            HttpContext.Current.GetRequestServices()
+                .GetServices(serviceType);
+
+        /// <summary>
+        ///   Scope is managed by <see cref="Unravel.SystemWeb.ServiceScopeModule"/>.
+        /// </summary>
+        /// <returns>The current instance.</returns>
+        public IDependencyScope BeginScope() => this;
+
+        /// <summary>
+        ///   Scope is managed by <see cref="Unravel.SystemWeb.ServiceScopeModule"/>.
+        /// </summary>
+        public void Dispose() { }
+    }
+}

--- a/src/AspNet.WebApi/DependencyInjection/UnravelAspNetWebApiBuilderExtensions.cs
+++ b/src/AspNet.WebApi/DependencyInjection/UnravelAspNetWebApiBuilderExtensions.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Web.Http.Controllers;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    ///   Extensions for configuring ASP.NET Web API using an <see cref="IAspNetWebApiBuilder"/>.
+    /// </summary>
+    public static class UnravelAspNetWebApiBuilderExtensions
+    {
+        /// <summary>
+        ///   Registers controllers discovered in <see cref="IHostingEnvironment.ApplicationName"/>
+        ///   as services in the <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="builder">The <see cref="IAspNetWebApiBuilder"/>.</param>
+        /// <returns>The <see cref="IAspNetWebApiBuilder"/>.</returns>
+        public static IAspNetWebApiBuilder AddControllersAsServices(this IAspNetWebApiBuilder builder)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            // https://github.com/dotnet/aspnetcore/blob/c2cfc5f140cd2743ecc33eeeb49c5a2dd35b017f/src/Mvc/Mvc.Core/src/DependencyInjection/MvcCoreServiceCollectionExtensions.cs#L83-L90
+            var environment = GetServiceFromCollection<IHostingEnvironment>(builder.Services);
+            var entryAssemblyName = environment?.ApplicationName;
+            if (string.IsNullOrEmpty(entryAssemblyName))
+                return builder;
+
+            var entryAssembly = Assembly.Load(new AssemblyName(entryAssemblyName));
+            return builder.AddControllersAsServices(entryAssembly);
+        }
+
+        /// <summary>
+        ///   Registers controllers discovered in <paramref name="assembly"/>
+        ///   as services in the <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="builder">The <see cref="IAspNetWebApiBuilder"/>.</param>
+        /// <param name="assembly">The <see cref="Assembly"/> to scan.</param>
+        /// <returns>The <see cref="IAspNetWebApiBuilder"/>.</returns>
+        public static IAspNetWebApiBuilder AddControllersAsServices(this IAspNetWebApiBuilder builder, Assembly assembly)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (assembly == null)
+            {
+                throw new ArgumentNullException(nameof(assembly));
+            }
+
+            var services = builder.Services;
+
+            var controllerType = typeof(IHttpController);
+
+            foreach (var type in assembly.GetExportedTypes())
+            {
+                if (type.IsAbstract || type.IsGenericTypeDefinition)
+                    continue;
+
+                if (!controllerType.IsAssignableFrom(type))
+                    continue;
+
+                if (!type.Name.EndsWith("Controller", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                services.AddTransient(type);
+            }
+
+            return builder;
+        }
+
+        private static T GetServiceFromCollection<T>(IServiceCollection services)
+        {
+            return (T)services
+                .LastOrDefault(d => d.ServiceType == typeof(T))
+                ?.ImplementationInstance;
+        }
+    }
+}

--- a/src/AspNet.WebApi/DependencyInjection/UnravelAspNetWebApiServiceCollectionExtensions.cs
+++ b/src/AspNet.WebApi/DependencyInjection/UnravelAspNetWebApiServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System.Web.Http.Dependencies;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Unravel.AspNet.WebApi.DependencyInjection.Internal;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    ///   Extension methods for setting up ASP.NET Web API services in an <see cref="IServiceCollection" />.
+    /// </summary>
+    public static class UnravelAspNetWebApiServiceCollectionExtensions
+    {
+        /// <summary>
+        ///   Adds ASP.NET Web API services to the specified <see cref="IServiceCollection" />, including:
+        ///   <list type="bullet">
+        ///     <item><see cref="GlobalConfigurationStartupFilter"/> as <see cref="IStartupFilter"/></item>
+        ///     <item><see cref="ServiceProviderDependencyResolver"/> as <see cref="IDependencyResolver"/></item>
+        ///   </list>
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <returns>An <see cref="IAspNetWebApiBuilder"/> that can be used to further configure the Web API services.</returns>
+        public static IAspNetWebApiBuilder AddAspNetWebApi(this IServiceCollection services)
+        {
+            services.AddSingleton<IStartupFilter, GlobalConfigurationStartupFilter>();
+            services.TryAddSingleton<IDependencyResolver, ServiceProviderDependencyResolver>();
+
+            return new AspNetWebApiBuilder(services);
+        }
+    }
+}

--- a/src/AspNet.WebApi/Unravel.AspNet.WebApi.csproj
+++ b/src/AspNet.WebApi/Unravel.AspNet.WebApi.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <AssemblyName>Unravel.AspNet.WebApi</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Startup\Unravel.Startup.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Web" />
+  </ItemGroup>
+
+</Project>

--- a/src/AspNetCore.Mvc/DependencyInjection/UnravelAspNetCoreMvcBuilderExtensions.cs
+++ b/src/AspNetCore.Mvc/DependencyInjection/UnravelAspNetCoreMvcBuilderExtensions.cs
@@ -13,9 +13,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <typeparam name="TController">The controller base type to ignore.</typeparam>
         /// <returns>The <see cref="IMvcBuilder"/>.</returns>
-        public static void IgnoreControllersOfType<TController>(this IMvcBuilder builder)
+        public static IMvcBuilder IgnoreControllersOfType<TController>(this IMvcBuilder builder)
         {
             builder.Services.AddIgnoreControllersOfTypeActionInvokerProvider<TController>();
+            return builder;
         }
     }
 }

--- a/src/AspNetCore.Mvc/DependencyInjection/UnravelAspNetCoreMvcCoreBuilderExtensions.cs
+++ b/src/AspNetCore.Mvc/DependencyInjection/UnravelAspNetCoreMvcCoreBuilderExtensions.cs
@@ -13,9 +13,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <typeparam name="TController">The controller base type to ignore.</typeparam>
         /// <returns>The <see cref="IMvcCoreBuilder"/>.</returns>
-        public static void IgnoreControllersOfType<TController>(this IMvcCoreBuilder builder)
+        public static IMvcCoreBuilder IgnoreControllersOfType<TController>(this IMvcCoreBuilder builder)
         {
             builder.Services.AddIgnoreControllersOfTypeActionInvokerProvider<TController>();
+            return builder;
         }
     }
 }


### PR DESCRIPTION
Twin to #3. `GlobalConfigurationStartupFilter` could be extended to set up other stuff from configured services. We could conceivably shift most of the stuff that has traditionally lived in `Application_Start()` to use a pattern more like ASP.NET Core.