### PR TITLE
`HttpPostedFileBase` ➡️ `IFormFile`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ indent_style = space
 [*.{cs,csx,vb,vbx}]
 indent_size = 4
 insert_final_newline = true
-charset = utf-8-bom
+charset = utf-8
 ###############################
 # .NET Coding Conventions     #
 ###############################

--- a/README.md
+++ b/README.md
@@ -94,6 +94,37 @@ public override void ConfigureServices(IServiceCollection services)
 }
 ```
 
+### `MvcOptions`
+
+Also similar to ASP.NET Core 2.1, `AddAspNetMvc()` accepts an optional `Action<MvcOptions>` to consolidate configuration, including:
+
+```csharp
+        .AddAspNetMvc(options =>
+        {
+            // Equivalent to AreaRegistration.RegisterAllAreas()
+            options.RegisterAllAreas();
+
+            // Equivalent to MvcHandler.DisableMvcResponseHeader
+            options.DisableMvcResponseHeader = true;
+
+            // Equivalent to GlobalFilters.Filters.Add(...)
+            options.Filters.Add(...);
+
+            // Equivalent to ModelBinders.Binders.Add(...)
+            options.ModelBinders.Add(...);
+
+            // Equivalent to RouteTable.Routes.MapRoute(...);
+            options.Routes.MapRoute(...);
+        })
+```
+
+### `IFormFile` Model Binder
+
+`AddAspNetMvc()` registers a model binder for `IFormFile`, to replace references to
+[`System.Web.HttpPostedFileBase`](https://docs.microsoft.com/en-us/dotnet/api/system.web.httppostedfilebase?view=netframework-4.8).
+
+Some `IFormFile` properties are not supported, due to `HttpPostedFileBase` limitations.
+
 ## Unravel.AspNet.WebApi
 
 Similar to `AddAspNetMvc()` described above, there's also an `AddAspNetWebApi()` extension method on `IServiceCollection` that registers a `System.Web.Http.Dependencies.IDependencyResolver`.

--- a/examples/Web/Controllers/AspNetMvcController.cs
+++ b/examples/Web/Controllers/AspNetMvcController.cs
@@ -18,5 +18,25 @@ namespace UnravelExamples.Web.Controllers
             var env = new EnvironmentCheck("ASP.NET MVC Controller Injection", services);
             return Content(env.ToString(), "application/json; charset=utf-8");
         }
+
+        public ActionResult Upload(Microsoft.AspNetCore.Http.IFormFile testFile)
+        {
+            return Json(new
+            {
+                testFile.Name,
+                testFile.FileName,
+                testFile.ContentType,
+                testFile.Length,
+                Bytes = ReadContent(),
+            });
+
+            byte[] ReadContent()
+            {
+                byte[] buffer = new byte[testFile.Length];
+                using (var stream = testFile.OpenReadStream())
+                    stream.Read(buffer, 0, (int)testFile.Length);
+                return buffer;
+            }
+        }
     }
 }

--- a/examples/Web/Global.asax.cs
+++ b/examples/Web/Global.asax.cs
@@ -1,7 +1,5 @@
 using System.Web.Http;
-using System.Web.Mvc;
 using System.Web.Optimization;
-using System.Web.Routing;
 
 namespace UnravelExamples.Web
 {
@@ -9,10 +7,7 @@ namespace UnravelExamples.Web
     {
         protected void Application_Start()
         {
-            AreaRegistration.RegisterAllAreas();
             GlobalConfiguration.Configure(WebApiConfig.Register);
-            FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
-            RouteConfig.RegisterRoutes(RouteTable.Routes);
             BundleConfig.RegisterBundles(BundleTable.Bundles);
         }
     }

--- a/examples/Web/Startup.cs
+++ b/examples/Web/Startup.cs
@@ -11,7 +11,15 @@ namespace UnravelExamples.Web
         {
             Counters.Register(services);
 
-            services.AddAspNetMvc()
+            services
+                .AddAspNetMvc(options =>
+                {
+                    options.RegisterAllAreas();
+
+                    FilterConfig.RegisterGlobalFilters(options.Filters);
+
+                    RouteConfig.RegisterRoutes(options.Routes);
+                })
                 .AddControllersAsServices()
                 ;
 

--- a/examples/Web/Views/Home/Index.cshtml
+++ b/examples/Web/Views/Home/Index.cshtml
@@ -12,6 +12,12 @@
         <li><a target="env" href="@Url.Action(nameof(HomeController.HttpContextBase_GetRequestServices))"><code>HttpContextBase.GetRequestServices()</code></a></li>
         <li><a target="env" href="@Url.Action(nameof(HomeController.Throw))"><code>throw</code></a></li>
         <li><a target="env" href="@Url.Action(nameof(AspNetMvcController.Index), "AspNetMvc")">Constructor Injection</a></li>
+        <li>
+            <form target="env" method="post" action="@Url.Action(nameof(AspNetMvcController.Upload), "AspNetMvc")" enctype="multipart/form-data">
+                <input type="file" name="testFile" />
+                <input type="submit" />
+            </form>
+        </li>
     </ul>
 
     <h2>ASP.NET WebApi</h2>

--- a/src/AspNet.Mvc/DependencyInjection/UnravelAspNetMvcServiceCollectionExtensions.cs
+++ b/src/AspNet.Mvc/DependencyInjection/UnravelAspNetMvcServiceCollectionExtensions.cs
@@ -1,7 +1,10 @@
-﻿using System.Web.Mvc;
+using System;
+using System.Web.Mvc;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Unravel.AspNet.Mvc;
 using Unravel.AspNet.Mvc.DependencyInjection.Internal;
+using Unravel.AspNet.Mvc.Internal;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -24,7 +27,29 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IStartupFilter, DependencyResolverStartupFilter>();
             services.TryAddSingleton<IDependencyResolver, ServiceProviderDependencyResolver>();
 
+            services.AddSingleton<IStartupFilter, MvcOptionsStartupFilter>();
+
             return new AspNetMvcBuilder(services);
+        }
+
+        /// <inheritdoc cref="AddAspNetMvc(IServiceCollection)"/>
+        /// <param name="setupAction">An <see cref="Action{MvcOptions}"/> to configure the provided <see cref="MvcOptions"/>.</param>
+        public static IAspNetMvcBuilder AddAspNetMvc(this IServiceCollection services, Action<MvcOptions> setupAction)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (setupAction == null)
+            {
+                throw new ArgumentNullException(nameof(setupAction));
+            }
+
+            var builder = services.AddAspNetMvc();
+            builder.Services.Configure(setupAction);
+
+            return builder;
         }
     }
 }

--- a/src/AspNet.Mvc/DependencyInjection/UnravelAspNetMvcServiceCollectionExtensions.cs
+++ b/src/AspNet.Mvc/DependencyInjection/UnravelAspNetMvcServiceCollectionExtensions.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Web.Mvc;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Unravel.AspNet.Mvc;
 using Unravel.AspNet.Mvc.DependencyInjection.Internal;
 using Unravel.AspNet.Mvc.Internal;
+using Unravel.AspNet.Mvc.ModelBinding;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -19,6 +21,10 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     <item><see cref="DependencyResolverStartupFilter"/> as <see cref="IStartupFilter"/></item>
         ///     <item><see cref="ServiceProviderDependencyResolver"/> as <see cref="IDependencyResolver"/></item>
         ///   </list>
+        ///   Also adds useful MVC configuration:
+        ///   <list type="bullet">
+        ///     <item><see cref="IFormFile"/> model binding with <see cref="HttpPostedFormFileModelBinder"/></item>
+        ///   </list>
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
         /// <returns>An <see cref="IAspNetMvcBuilder"/> that can be used to further configure the MVC services.</returns>
@@ -28,8 +34,14 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<IDependencyResolver, ServiceProviderDependencyResolver>();
 
             services.AddSingleton<IStartupFilter, MvcOptionsStartupFilter>();
+            services.Configure<MvcOptions>(ConfigureOptions);
 
             return new AspNetMvcBuilder(services);
+
+            void ConfigureOptions(MvcOptions options)
+            {
+                options.ModelBinders.Add(typeof(IFormFile), new HttpPostedFormFileModelBinder());
+            }
         }
 
         /// <inheritdoc cref="AddAspNetMvc(IServiceCollection)"/>

--- a/src/AspNet.Mvc/Internal/MvcOptionsStartupFilter.cs
+++ b/src/AspNet.Mvc/Internal/MvcOptionsStartupFilter.cs
@@ -1,0 +1,24 @@
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Unravel.AspNet.Mvc.Internal
+{
+    /// <summary>
+    /// Resolves <see cref="MvcOptions"/> to apply configuration.
+    /// </summary>
+    public class MvcOptionsStartupFilter : IStartupFilter
+    {
+        public MvcOptionsStartupFilter(IOptions<MvcOptions> options)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            if (options.Value == null)
+                throw new InvalidOperationException($"{nameof(MvcOptions)} not found.");
+        }
+
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) => next;
+    }
+}

--- a/src/AspNet.Mvc/ModelBinding/HttpPostedFormFileModelBinder.cs
+++ b/src/AspNet.Mvc/ModelBinding/HttpPostedFormFileModelBinder.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+// See https://github.com/aspnet/AspNetWebStack/blob/a68a57535d0adeda2b1846764e5eafd02fdeb12d/LICENSE.txt for license information.
+// https://github.com/aspnet/AspNetWebStack/blob/a68a57535d0adeda2b1846764e5eafd02fdeb12d/src/System.Web.Mvc/HttpPostedFileBaseModelBinder.cs
+
+using System;
+using System.Web;
+using System.Web.Mvc;
+using Microsoft.AspNetCore.Http;
+
+namespace Unravel.AspNet.Mvc.ModelBinding
+{
+    public class HttpPostedFormFileModelBinder : IModelBinder
+    {
+        public object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)
+        {
+            if (controllerContext == null)
+            {
+                throw new ArgumentNullException(nameof(controllerContext));
+            }
+            if (bindingContext == null)
+            {
+                throw new ArgumentNullException(nameof(bindingContext));
+            }
+
+            var name = bindingContext.ModelName;
+            var theFile = controllerContext.HttpContext.Request.Files[name];
+            return ChooseFileOrNull(name, theFile);
+        }
+
+        // helper that returns the original file if there was content uploaded, null if empty
+        internal static IFormFile ChooseFileOrNull(string name, HttpPostedFileBase rawFile)
+        {
+            // case 1: there was no <input type="file" ... /> element in the post
+            if (rawFile == null)
+            {
+                return null;
+            }
+
+            // case 2: there was an <input type="file" ... /> element in the post, but it was left blank
+            if (rawFile.ContentLength == 0 && string.IsNullOrEmpty(rawFile.FileName))
+            {
+                return null;
+            }
+
+            // case 3: the file was posted
+            return new Internal.HttpPostedFormFile(name, rawFile);
+        }
+    }
+}

--- a/src/AspNet.Mvc/ModelBinding/Internal/HttpPostedFormFile.cs
+++ b/src/AspNet.Mvc/ModelBinding/Internal/HttpPostedFormFile.cs
@@ -1,0 +1,94 @@
+// Portions Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+// See https://github.com/dotnet/aspnetcore/blob/c2cfc5f140cd2743ecc33eeeb49c5a2dd35b017f/LICENSE.txt for license information.
+// https://github.com/dotnet/aspnetcore/blob/c2cfc5f140cd2743ecc33eeeb49c5a2dd35b017f/src/Http/Http/src/Internal/FormFile.cs
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using Microsoft.AspNetCore.Http;
+
+namespace Unravel.AspNet.Mvc.ModelBinding.Internal
+{
+    /// <summary>
+    /// <see cref="IFormFile"/> wrapper for an <see cref="HttpPostedFileBase"/>.
+    /// </summary>
+    public class HttpPostedFormFile : IFormFile
+    {
+        // Stream.CopyTo method uses 80KB as the default buffer size.
+        private const int DefaultBufferSize = 80 * 1024;
+
+        /// <summary>
+        /// Initializes a new <see cref="HttpPostedFormFile"/>.
+        /// </summary>
+        /// <param name="name">The form field name.</param>
+        /// <param name="file">The uploaded file.</param>
+        public HttpPostedFormFile(string name, HttpPostedFileBase file)
+        {
+            Name = name;
+            File = file ?? throw new ArgumentNullException(nameof(file));
+        }
+
+        /// <summary>
+        /// The wrapped <see cref="HttpPostedFileBase"/>.
+        /// </summary>
+        public HttpPostedFileBase File { get; }
+
+        /// <inheritdoc/>
+        public string ContentType => File.ContentType;
+
+        /// <inheritdoc/>
+        /// <exception cref="NotSupportedException">Always thrown.</exception>
+        public string ContentDisposition => throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        /// <exception cref="NotSupportedException">Always thrown.</exception>
+        public IHeaderDictionary Headers => throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        public long Length => File.ContentLength;
+
+        /// <inheritdoc/>
+        public string Name { get; }
+
+        /// <inheritdoc/>
+        public string FileName => File.FileName;
+
+        public Stream OpenReadStream()
+        {
+            return new ReferenceReadStream(File.InputStream, 0, Length);
+        }
+
+        /// <inheritdoc/>
+        /// <exception cref="ArgumentNullException"><paramref name="target"/> is <see langword="null"/>.</exception>
+        public void CopyTo(Stream target)
+        {
+            if (target == null)
+            {
+                throw new ArgumentNullException(nameof(target));
+            }
+
+            using (var readStream = OpenReadStream())
+            {
+                readStream.CopyTo(target, DefaultBufferSize);
+            }
+        }
+
+        /// <inheritdoc/>
+        /// <exception cref="ArgumentNullException"><paramref name="target"/> is <see langword="null"/>.</exception>
+        public async Task CopyToAsync(Stream target, CancellationToken cancellationToken = default)
+        {
+            if (target == null)
+            {
+                throw new ArgumentNullException(nameof(target));
+            }
+
+            using (var readStream = OpenReadStream())
+            {
+                await readStream.CopyToAsync(target, DefaultBufferSize, cancellationToken);
+            }
+        }
+    }
+}

--- a/src/AspNet.Mvc/ModelBinding/Internal/ReferenceReadStream.cs
+++ b/src/AspNet.Mvc/ModelBinding/Internal/ReferenceReadStream.cs
@@ -1,0 +1,157 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+// See https://github.com/dotnet/aspnetcore/blob/c2cfc5f140cd2743ecc33eeeb49c5a2dd35b017f/LICENSE.txt for license information.
+// https://github.com/dotnet/aspnetcore/blob/c2cfc5f140cd2743ecc33eeeb49c5a2dd35b017f/src/Http/Http/src/Internal/ReferenceReadStream.cs
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Unravel.AspNet.Mvc.ModelBinding.Internal
+{
+    /// <summary>
+    /// A <see cref="Stream"/> that wraps another stream starting at a certain offset and reading for the given length.
+    /// </summary>
+    internal class ReferenceReadStream : Stream
+    {
+        private readonly Stream _inner;
+        private readonly long _innerOffset;
+        private readonly long _length;
+        private long _position;
+
+        private bool _disposed;
+
+        public ReferenceReadStream(Stream inner, long offset, long length)
+        {
+            if (inner == null)
+            {
+                throw new ArgumentNullException(nameof(inner));
+            }
+
+            _inner = inner;
+            _innerOffset = offset;
+            _length = length;
+            _inner.Position = offset;
+        }
+
+        public override bool CanRead
+        {
+            get { return true; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return _inner.CanSeek; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
+
+        public override long Length
+        {
+            get { return _length; }
+        }
+
+        public override long Position
+        {
+            get { return _position; }
+            set
+            {
+                ThrowIfDisposed();
+                if (value < 0 || value > Length)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "The Position must be within the length of the Stream: " + Length.ToString());
+                }
+                VerifyPosition();
+                _position = value;
+                _inner.Position = _innerOffset + _position;
+            }
+        }
+
+        // Throws if the position in the underlying stream has changed without our knowledge, indicating someone else is trying
+        // to use the stream at the same time which could lead to data corruption.
+        private void VerifyPosition()
+        {
+            if (_inner.Position != _innerOffset + _position)
+            {
+                throw new InvalidOperationException("The inner stream position has changed unexpectedly.");
+            }
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            if (origin == SeekOrigin.Begin)
+            {
+                Position = offset;
+            }
+            else if (origin == SeekOrigin.End)
+            {
+                Position = Length + offset;
+            }
+            else // if (origin == SeekOrigin.Current)
+            {
+                Position = Position + offset;
+            }
+            return Position;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ThrowIfDisposed();
+            VerifyPosition();
+            var toRead = Math.Min(count, _length - _position);
+            var read = _inner.Read(buffer, offset, (int)toRead);
+            _position += read;
+            return read;
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+            VerifyPosition();
+            var toRead = Math.Min(count, _length - _position);
+            var read = await _inner.ReadAsync(buffer, offset, (int)toRead, cancellationToken);
+            _position += read;
+            return read;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _disposed = true;
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(ReferenceReadStream));
+            }
+        }
+    }
+}

--- a/src/AspNet.Mvc/MvcOptions.cs
+++ b/src/AspNet.Mvc/MvcOptions.cs
@@ -1,0 +1,37 @@
+namespace Unravel.AspNet.Mvc
+{
+    /// <summary>
+    /// Provides consolidated programmatic configuration for the ASP.NET MVC framework.
+    /// </summary>
+    public class MvcOptions
+    {
+        /// <inheritdoc cref="System.Web.Mvc.MvcHandler.DisableMvcResponseHeader"/>
+        public bool DisableMvcResponseHeader
+        {
+            get => System.Web.Mvc.MvcHandler.DisableMvcResponseHeader;
+            set => System.Web.Mvc.MvcHandler.DisableMvcResponseHeader = value;
+        }
+
+        /// <inheritdoc cref="GlobalFilters.Filters"/>
+        public System.Web.Mvc.GlobalFilterCollection Filters =>
+            System.Web.Mvc.GlobalFilters.Filters;
+
+        /// <inheritdoc cref="System.Web.ModelBinding.ModelBinders.Binders"/>
+        public System.Web.Mvc.ModelBinderDictionary ModelBinders =>
+            System.Web.Mvc.ModelBinders.Binders;
+
+        /// <inheritdoc cref="System.Web.ModelBinding.ModelBinderProviders.Providers"/>
+        public System.Web.Mvc.ModelBinderProviderCollection ModelBinderProviders =>
+            System.Web.Mvc.ModelBinderProviders.BinderProviders;
+
+        /// <inheritdoc cref="System.Web.Routing.RouteTable.Routes"/>
+        public System.Web.Routing.RouteCollection Routes =>
+            System.Web.Routing.RouteTable.Routes;
+
+        /// <inheritdoc cref="System.Web.Mvc.AreaRegistration.RegisterAllAreas()"/>
+        public void RegisterAllAreas() => System.Web.Mvc.AreaRegistration.RegisterAllAreas();
+
+        /// <inheritdoc cref="System.Web.Mvc.AreaRegistration.RegisterAllAreas(object)"/>
+        public void RegisterAllAreas(object state) => System.Web.Mvc.AreaRegistration.RegisterAllAreas(state);
+    }
+}


### PR DESCRIPTION
One of the easiest first steps towards Core is replacing `HttpPostedFileBase` with `IFormFile`.

Needed a configurable way to wire up the new model binder, so implemented an [`MvcOptions`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.mvcoptions?view=aspnetcore-2.1)-style configuration mechanism that's a simple wrapper around common MVC config. There is probably other config that could be added there, and a similar overload for `AddAspNetWebApi()` could replace [`GlobalConfiguration.Configure()`](https://docs.microsoft.com/en-us/previous-versions/aspnet/mt134853(v=vs.118)). From a migration standpoint it seems handy to see all the legacy configuration in one place.