### PR TITLE
Fix References + Update Packages

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Start IIS Express
       run: |
         $URL = .\util\Start-IisExpress.ps1 -Path .\examples\Web
+        if (!$URL) { exit 1 }
         "URL=$URL" | Out-File -Append -Encoding utf8 -FilePath $Env:GITHUB_ENV
 
     - name: Check Connection

--- a/examples/Identity/UnravelExamples.Identity.csproj
+++ b/examples/Identity/UnravelExamples.Identity.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\EntityFramework.6.4.4\build\EntityFramework.props" Condition="Exists('..\..\packages\EntityFramework.6.4.4\build\EntityFramework.props')" />
   <Import Project="..\..\packages\MSBuild.Microsoft.VisualStudio.Web.targets.14.0.0.3\build\MSBuild.Microsoft.VisualStudio.Web.targets.props" Condition="Exists('..\..\packages\MSBuild.Microsoft.VisualStudio.Web.targets.14.0.0.3\build\MSBuild.Microsoft.VisualStudio.Web.targets.props')" />
   <Import Project="..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets" Condition="Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" />
   <Import Project="..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.props" Condition="Exists('..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.props')" />
@@ -51,11 +52,11 @@
       <Private>True</Private>
       <HintPath>..\..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="EntityFramework">
-      <HintPath>..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EntityFramework.6.4.4\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
-    <Reference Include="EntityFramework.SqlServer">
-      <HintPath>..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EntityFramework.6.4.4\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Hosting, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Hosting.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Hosting.dll</HintPath>
@@ -381,8 +382,11 @@
     <Error Condition="!Exists('..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.targets'))" />
     <Error Condition="!Exists('..\..\packages\MSBuild.Microsoft.VisualStudio.Web.targets.14.0.0.3\build\MSBuild.Microsoft.VisualStudio.Web.targets.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSBuild.Microsoft.VisualStudio.Web.targets.14.0.0.3\build\MSBuild.Microsoft.VisualStudio.Web.targets.props'))" />
+    <Error Condition="!Exists('..\..\packages\EntityFramework.6.4.4\build\EntityFramework.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\EntityFramework.6.4.4\build\EntityFramework.props'))" />
+    <Error Condition="!Exists('..\..\packages\EntityFramework.6.4.4\build\EntityFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\EntityFramework.6.4.4\build\EntityFramework.targets'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.targets" Condition="Exists('..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.targets')" />
+  <Import Project="..\..\packages\EntityFramework.6.4.4\build\EntityFramework.targets" Condition="Exists('..\..\packages\EntityFramework.6.4.4\build\EntityFramework.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/examples/Identity/UnravelExamples.Identity.csproj
+++ b/examples/Identity/UnravelExamples.Identity.csproj
@@ -47,6 +47,16 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Antlr3.Runtime">
+      <Private>True</Private>
+      <HintPath>..\..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework">
+      <HintPath>..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer">
+      <HintPath>..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.AspNetCore.Hosting, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Hosting.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Hosting.dll</HintPath>
     </Reference>
@@ -67,6 +77,15 @@
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Http.Features, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Http.Features.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Http.Features.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNet.Identity.Core">
+      <HintPath>..\..\packages\Microsoft.AspNet.Identity.Core.2.2.3\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNet.Identity.Owin">
+      <HintPath>..\..\packages\Microsoft.AspNet.Identity.Owin.2.2.3\lib\net45\Microsoft.AspNet.Identity.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNet.Identity.EntityFramework">
+      <HintPath>..\..\packages\Microsoft.AspNet.Identity.EntityFramework.2.2.3\lib\net45\Microsoft.AspNet.Identity.EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Owin, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Owin.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Owin.dll</HintPath>
@@ -171,6 +190,16 @@
     <Reference Include="Microsoft.Owin.Security.Twitter, Version=4.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Owin.Security.Twitter.4.2.0\lib\net45\Microsoft.Owin.Security.Twitter.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin">
+      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
@@ -178,14 +207,18 @@
     <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
     </Reference>
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
-    <Reference Include="System.Drawing" />
     <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Memory.4.5.1\lib\netstandard2.0\System.Memory.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
@@ -199,21 +232,26 @@
     <Reference Include="System.Text.Encodings.Web, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Text.Encodings.Web.4.5.0\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
-    <Reference Include="System.Web.ApplicationServices" />
-    <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.2.9\lib\net45\System.Web.Helpers.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Mvc, Version=5.2.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.Mvc.5.2.9\lib\net45\System.Web.Mvc.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web.Optimization">
+      <HintPath>..\..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.Razor.3.2.9\lib\net45\System.Web.Razor.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web.Routing" />
+    <Reference Include="System.Web.Services" />
     <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.2.9\lib\net45\System.Web.WebPages.dll</HintPath>
     </Reference>
@@ -223,56 +261,10 @@
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.2.9\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Web.Abstractions" />
-    <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Web.Services" />
-    <Reference Include="System.EnterpriseServices" />
-    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http">
-    </Reference>
-    <Reference Include="System.Net.Http.WebRequest">
-    </Reference>
-    <Reference Include="System.Web.Optimization">
-      <HintPath>..\..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="WebGrease">
       <Private>True</Private>
       <HintPath>..\..\packages\WebGrease.1.6.0\lib\WebGrease.dll</HintPath>
-    </Reference>
-    <Reference Include="Antlr3.Runtime">
-      <Private>True</Private>
-      <HintPath>..\..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="EntityFramework">
-      <HintPath>..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="EntityFramework.SqlServer">
-      <HintPath>..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNet.Identity.Core">
-      <HintPath>..\..\packages\Microsoft.AspNet.Identity.Core.2.2.3\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNet.Identity.Owin">
-      <HintPath>..\..\packages\Microsoft.AspNet.Identity.Owin.2.2.3\lib\net45\Microsoft.AspNet.Identity.Owin.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNet.Identity.EntityFramework">
-      <HintPath>..\..\packages\Microsoft.AspNet.Identity.EntityFramework.2.2.3\lib\net45\Microsoft.AspNet.Identity.EntityFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="Owin">
-      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/examples/Identity/UnravelExamples.Identity.csproj
+++ b/examples/Identity/UnravelExamples.Identity.csproj
@@ -169,26 +169,26 @@
     <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Owin.Host.SystemWeb.4.2.2\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security, Version=4.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Owin.Security.4.2.0\lib\net45\Microsoft.Owin.Security.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Security.4.2.2\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.Cookies, Version=4.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Owin.Security.Cookies.4.2.0\lib\net45\Microsoft.Owin.Security.Cookies.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security.Cookies, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Security.Cookies.4.2.2\lib\net45\Microsoft.Owin.Security.Cookies.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.Facebook, Version=4.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Owin.Security.Facebook.4.2.0\lib\net45\Microsoft.Owin.Security.Facebook.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security.Facebook, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Security.Facebook.4.2.2\lib\net45\Microsoft.Owin.Security.Facebook.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.Google, Version=4.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Owin.Security.Google.4.2.0\lib\net45\Microsoft.Owin.Security.Google.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security.Google, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Security.Google.4.2.2\lib\net45\Microsoft.Owin.Security.Google.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.MicrosoftAccount, Version=4.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Owin.Security.MicrosoftAccount.4.2.0\lib\net45\Microsoft.Owin.Security.MicrosoftAccount.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security.MicrosoftAccount, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Security.MicrosoftAccount.4.2.2\lib\net45\Microsoft.Owin.Security.MicrosoftAccount.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.OAuth, Version=4.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Owin.Security.OAuth.4.2.0\lib\net45\Microsoft.Owin.Security.OAuth.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security.OAuth, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Security.OAuth.4.2.2\lib\net45\Microsoft.Owin.Security.OAuth.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.Twitter, Version=4.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Owin.Security.Twitter.4.2.0\lib\net45\Microsoft.Owin.Security.Twitter.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security.Twitter, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Security.Twitter.4.2.2\lib\net45\Microsoft.Owin.Security.Twitter.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
@@ -229,6 +229,7 @@
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
+    <Reference Include="System.Security" />
     <Reference Include="System.Text.Encodings.Web, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Text.Encodings.Web.4.5.1\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
     </Reference>

--- a/examples/Identity/UnravelExamples.Identity.csproj
+++ b/examples/Identity/UnravelExamples.Identity.csproj
@@ -211,8 +211,8 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Memory.4.5.1\lib\netstandard2.0\System.Memory.dll</HintPath>

--- a/examples/Identity/UnravelExamples.Identity.csproj
+++ b/examples/Identity/UnravelExamples.Identity.csproj
@@ -190,9 +190,8 @@
     <Reference Include="Microsoft.Owin.Security.Twitter, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Owin.Security.Twitter.4.2.2\lib\net45\Microsoft.Owin.Security.Twitter.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    <Reference Include="Microsoft.Web.Infrastructure, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Web.Infrastructure.2.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/examples/Identity/UnravelExamples.Identity.csproj
+++ b/examples/Identity/UnravelExamples.Identity.csproj
@@ -66,14 +66,14 @@
     <Reference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Hosting.Server.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Hosting.Server.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Http, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNetCore.Http.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Http.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Http, Version=2.1.34.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Http.2.1.34\lib\netstandard2.0\Microsoft.AspNetCore.Http.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Http.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Http.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Http.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Http.Extensions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNetCore.Http.Extensions.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Http.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Http.Extensions, Version=2.1.21.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Http.Extensions.2.1.21\lib\netstandard2.0\Microsoft.AspNetCore.Http.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Http.Features, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Http.Features.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Http.Features.dll</HintPath>
@@ -103,8 +103,8 @@
     <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Binder.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=2.1.10.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Binder.2.1.10\lib\netstandard2.0\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
@@ -148,8 +148,8 @@
     <Reference Include="Microsoft.Extensions.Logging.Debug, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.Debug.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Logging.Debug.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.ObjectPool, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.ObjectPool.2.1.1\lib\netstandard2.0\Microsoft.Extensions.ObjectPool.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.ObjectPool, Version=2.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.ObjectPool.2.1.6\lib\netstandard2.0\Microsoft.Extensions.ObjectPool.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Options, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Options.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
@@ -157,11 +157,11 @@
     <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.Primitives.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=2.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Primitives.2.1.6\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Net.Http.Headers, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Net.Http.Headers.2.1.1\lib\netstandard2.0\Microsoft.Net.Http.Headers.dll</HintPath>
+    <Reference Include="Microsoft.Net.Http.Headers, Version=2.1.14.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Net.Http.Headers.2.1.14\lib\netstandard2.0\Microsoft.Net.Http.Headers.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Owin.4.2.2\lib\net45\Microsoft.Owin.dll</HintPath>
@@ -202,7 +202,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+      <HintPath>..\..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
@@ -214,23 +214,23 @@
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
-    <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Memory.4.5.1\lib\netstandard2.0\System.Memory.dll</HintPath>
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
     <Reference Include="System.Reflection.Metadata, Version=1.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reflection.Metadata.1.6.0\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.1\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Text.Encodings.Web.4.5.0\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Text.Encodings.Web.4.5.1\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />

--- a/examples/Identity/UnravelExamples.Identity.csproj
+++ b/examples/Identity/UnravelExamples.Identity.csproj
@@ -274,9 +274,6 @@
     <Reference Include="Owin">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.Cookies">
-      <HintPath>..\..\packages\Microsoft.Owin.Security.Cookies.4.0.1\lib\net45\Microsoft.Owin.Security.Cookies.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Start\BundleConfig.cs" />

--- a/examples/Identity/UnravelExamples.Identity.csproj
+++ b/examples/Identity/UnravelExamples.Identity.csproj
@@ -194,8 +194,8 @@
       <Private>True</Private>
       <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/examples/Identity/Web.config
+++ b/examples/Identity/Web.config
@@ -81,6 +81,34 @@
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.1" newVersion="4.0.3.1" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.AspNetCore.Http" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.34.0" newVersion="2.1.34.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.6.0" newVersion="2.1.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.1" newVersion="4.0.3.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.ObjectPool" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.6.0" newVersion="2.1.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.10.0" newVersion="2.1.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Net.Http.Headers" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.14.0" newVersion="2.1.14.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>

--- a/examples/Identity/Web.config
+++ b/examples/Identity/Web.config
@@ -77,6 +77,10 @@
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="1.0.0.0-5.2.9.0" newVersion="5.2.9.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.1" newVersion="4.0.3.1" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>

--- a/examples/Identity/Web.config
+++ b/examples/Identity/Web.config
@@ -109,6 +109,10 @@
         <assemblyIdentity name="Microsoft.Net.Http.Headers" publicKeyToken="adb9793829ddae60" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.1.14.0" newVersion="2.1.14.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Web.Infrastructure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>

--- a/examples/Identity/Web.config
+++ b/examples/Identity/Web.config
@@ -31,15 +31,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" />

--- a/examples/Identity/Web.config
+++ b/examples/Identity/Web.config
@@ -9,7 +9,7 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <connectionStrings>
-    <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\aspnet-UnravelExamples.Identity-20211017021025.mdf;Initial Catalog=aspnet-UnravelExamples.Identity-20211017021025;Integrated Security=True" providerName="System.Data.SqlClient" />
+    <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\UnravelExamples.Identity.mdf;Initial Catalog=UnravelExamples.Identity;Integrated Security=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0" />

--- a/examples/Identity/Web.config
+++ b/examples/Identity/Web.config
@@ -59,7 +59,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/examples/Identity/packages.config
+++ b/examples/Identity/packages.config
@@ -9,39 +9,39 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.9" targetFramework="net472" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.9" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Hosting" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Hosting.Server.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http.Extensions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http.Features" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Owin" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.WebUtilities" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Hosting" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Hosting.Server.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Extensions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Features" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Owin" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.WebUtilities" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="4.1.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.Binder" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.FileExtensions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.Json" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.UserSecrets" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.FileProviders.Physical" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.FileSystemGlobbing" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Hosting.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Logging" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Logging.Configuration" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Logging.Debug" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.ObjectPool" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Options" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Primitives" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.FileExtensions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Json" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.UserSecrets" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.FileProviders.Physical" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.FileSystemGlobbing" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging.Configuration" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging.Debug" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.ObjectPool" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Options" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Primitives" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.11" targetFramework="net472" />
-  <package id="Microsoft.Net.Http.Headers" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.Net.Http.Headers" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Owin" version="4.2.2" targetFramework="net472" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="4.2.2" targetFramework="net472" />
   <package id="Microsoft.Owin.Security" version="4.2.0" targetFramework="net472" />
@@ -55,13 +55,13 @@
   <package id="MSBuild.Microsoft.VisualStudio.Web.targets" version="14.0.0.3" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
   <package id="Owin" version="1.0" targetFramework="net472" />
-  <package id="System.Buffers" version="4.5.0" targetFramework="net472" />
-  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net472" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net472" />
-  <package id="System.Memory" version="4.5.1" targetFramework="net472" />
-  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net472" />
-  <package id="System.Reflection.Metadata" version="1.6.0" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="4.5.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
+  <package id="System.Collections.Immutable" version="1.5.0" allowedVersions="[1.5.0,1.6.0)" targetFramework="net472" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.1" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.4.0" allowedVersions="[4.4.0,4.6.0)" targetFramework="net472" />
+  <package id="System.Reflection.Metadata" version="1.6.0" allowedVersions="[1.6.0,1.7.0)" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="WebGrease" version="1.6.0" targetFramework="net472" />
 </packages>

--- a/examples/Identity/packages.config
+++ b/examples/Identity/packages.config
@@ -57,7 +57,7 @@
   <package id="Owin" version="1.0" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net472" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net472" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net472" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net472" />
   <package id="System.Memory" version="4.5.1" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net472" />
   <package id="System.Reflection.Metadata" version="1.6.0" targetFramework="net472" />

--- a/examples/Identity/packages.config
+++ b/examples/Identity/packages.config
@@ -40,7 +40,7 @@
   <package id="Microsoft.Extensions.Options" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Primitives" version="2.1.6" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.11" targetFramework="net472" />
+  <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.11" allowedVersions="[3.2.11]" targetFramework="net472" />
   <package id="Microsoft.Net.Http.Headers" version="2.1.14" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Owin" version="4.2.2" targetFramework="net472" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="4.2.2" targetFramework="net472" />

--- a/examples/Identity/packages.config
+++ b/examples/Identity/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net472" />
-  <package id="EntityFramework" version="6.2.0" targetFramework="net472" />
+  <package id="EntityFramework" version="6.4.4" targetFramework="net472" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.Identity.EntityFramework" version="2.2.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.Identity.Owin" version="2.2.3" targetFramework="net472" />

--- a/examples/Identity/packages.config
+++ b/examples/Identity/packages.config
@@ -12,16 +12,16 @@
   <package id="Microsoft.AspNetCore.Hosting" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Hosting.Server.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http" version="2.1.34" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Http.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http.Extensions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Extensions" version="2.1.21" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Http.Features" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Owin" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.WebUtilities" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="4.1.0" targetFramework="net472" />
   <package id="Microsoft.Extensions.Configuration" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.Binder" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="2.1.10" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Configuration.FileExtensions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Configuration.Json" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
@@ -36,12 +36,12 @@
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Logging.Configuration" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Logging.Debug" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.Extensions.ObjectPool" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.ObjectPool" version="2.1.6" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Options" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Primitives" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Primitives" version="2.1.6" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.11" targetFramework="net472" />
-  <package id="Microsoft.Net.Http.Headers" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Net.Http.Headers" version="2.1.14" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Owin" version="4.2.2" targetFramework="net472" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="4.2.2" targetFramework="net472" />
   <package id="Microsoft.Owin.Security" version="4.2.0" targetFramework="net472" />
@@ -55,13 +55,13 @@
   <package id="MSBuild.Microsoft.VisualStudio.Web.targets" version="14.0.0.3" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
   <package id="Owin" version="1.0" targetFramework="net472" />
-  <package id="System.Buffers" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="System.Collections.Immutable" version="1.5.0" allowedVersions="[1.5.0,1.6.0)" targetFramework="net472" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
-  <package id="System.Memory" version="4.5.1" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
-  <package id="System.Numerics.Vectors" version="4.4.0" allowedVersions="[4.4.0,4.6.0)" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.5" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" allowedVersions="[4.4.0,4.6.0)" targetFramework="net472" />
   <package id="System.Reflection.Metadata" version="1.6.0" allowedVersions="[1.6.0,1.7.0)" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="4.5.1" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="WebGrease" version="1.6.0" targetFramework="net472" />
 </packages>

--- a/examples/Identity/packages.config
+++ b/examples/Identity/packages.config
@@ -51,7 +51,7 @@
   <package id="Microsoft.Owin.Security.MicrosoftAccount" version="4.2.2" targetFramework="net472" />
   <package id="Microsoft.Owin.Security.OAuth" version="4.2.2" targetFramework="net472" />
   <package id="Microsoft.Owin.Security.Twitter" version="4.2.2" targetFramework="net472" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
+  <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net472" />
   <package id="MSBuild.Microsoft.VisualStudio.Web.targets" version="14.0.0.3" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
   <package id="Owin" version="1.0" targetFramework="net472" />

--- a/examples/Identity/packages.config
+++ b/examples/Identity/packages.config
@@ -53,7 +53,7 @@
   <package id="Microsoft.Owin.Security.Twitter" version="4.2.0" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
   <package id="MSBuild.Microsoft.VisualStudio.Web.targets" version="14.0.0.3" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
   <package id="Owin" version="1.0" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net472" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net472" />

--- a/examples/Identity/packages.config
+++ b/examples/Identity/packages.config
@@ -44,13 +44,13 @@
   <package id="Microsoft.Net.Http.Headers" version="2.1.14" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Owin" version="4.2.2" targetFramework="net472" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="4.2.2" targetFramework="net472" />
-  <package id="Microsoft.Owin.Security" version="4.2.0" targetFramework="net472" />
-  <package id="Microsoft.Owin.Security.Cookies" version="4.2.0" targetFramework="net472" />
-  <package id="Microsoft.Owin.Security.Facebook" version="4.2.0" targetFramework="net472" />
-  <package id="Microsoft.Owin.Security.Google" version="4.2.0" targetFramework="net472" />
-  <package id="Microsoft.Owin.Security.MicrosoftAccount" version="4.2.0" targetFramework="net472" />
-  <package id="Microsoft.Owin.Security.OAuth" version="4.2.0" targetFramework="net472" />
-  <package id="Microsoft.Owin.Security.Twitter" version="4.2.0" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security" version="4.2.2" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security.Cookies" version="4.2.2" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security.Facebook" version="4.2.2" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security.Google" version="4.2.2" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security.MicrosoftAccount" version="4.2.2" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security.OAuth" version="4.2.2" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security.Twitter" version="4.2.2" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
   <package id="MSBuild.Microsoft.VisualStudio.Web.targets" version="14.0.0.3" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />

--- a/examples/Identity/packages.lock.json
+++ b/examples/Identity/packages.lock.json
@@ -268,45 +268,45 @@
       },
       "Microsoft.Owin.Security": {
         "type": "Direct",
-        "requested": "[4.2.0, 4.2.0]",
-        "resolved": "4.2.0",
-        "contentHash": "w/cWWNkc4sBRYHmY49VSfgKGEXVbBNecnrLR6sHf/shkRpFvitduo6dGUy/CwL3bQEFPEbuyQeXmMVVXQj3R4Q=="
+        "requested": "[4.2.2, 4.2.2]",
+        "resolved": "4.2.2",
+        "contentHash": "nEgJYWfSrbp/u2FnIkmiLUuWUyFX8xC/gtnwN9r1rV+iT/E10rMinGbaxQvSHlkhHBnUgzriYwCaMhMExxpyhQ=="
       },
       "Microsoft.Owin.Security.Cookies": {
         "type": "Direct",
-        "requested": "[4.2.0, 4.2.0]",
-        "resolved": "4.2.0",
-        "contentHash": "pH7EIIPO6/zu8Bz1SlJeUR+4o/iYo0tSmTzdRcPaK3Il1DixgXuiMAgSw6GrVLOqAYdv5YW2hWyRjseBRrWQAg=="
+        "requested": "[4.2.2, 4.2.2]",
+        "resolved": "4.2.2",
+        "contentHash": "/YTwRJlmJrsOXFT2KrkrQi32X54iNAae5Ev5tB5YK1069d/6U2tXxtheXkEG8UEf/1O57igfEMF7bk3fuOI6qg=="
       },
       "Microsoft.Owin.Security.Facebook": {
         "type": "Direct",
-        "requested": "[4.2.0, 4.2.0]",
-        "resolved": "4.2.0",
-        "contentHash": "AwxcJYZ6x8QVFE+Qpjj6yJ5Vsgls665TpvDjK86tHBUrQIuPr8Wf1z8y1+8aWOQm7vxOWgpjXDyjmPgCxCIo2w=="
+        "requested": "[4.2.2, 4.2.2]",
+        "resolved": "4.2.2",
+        "contentHash": "cK54wCDyw9pm6pE8AlhueHX8HrI6CP9oTSuILJXx7vB5PJ//b5dAJvEQbQThHVwK5LBpHxtSWwNRyaMpRKwSjA=="
       },
       "Microsoft.Owin.Security.Google": {
         "type": "Direct",
-        "requested": "[4.2.0, 4.2.0]",
-        "resolved": "4.2.0",
-        "contentHash": "tIwKhlIYIZsMJ6DFnCPOrthhzCdRo+qzmcfq/k8Pnu/asx/HkbCYJEeyJ4/pjhfWtj2YRrrJWUVsoJvQm/7U3A=="
+        "requested": "[4.2.2, 4.2.2]",
+        "resolved": "4.2.2",
+        "contentHash": "rlT2VAgMJC2is6j5dVSFq2dKBitmVF5j3rA+AQTzVQIOKcVHWstfvEI/3Bod7UIKosRsipcfNHkRI5uq73CZ2g=="
       },
       "Microsoft.Owin.Security.MicrosoftAccount": {
         "type": "Direct",
-        "requested": "[4.2.0, 4.2.0]",
-        "resolved": "4.2.0",
-        "contentHash": "xVL35AH35T/UWG4lrcWn/ww3Uy/dyX5MzdMDv8OxrtRj2JSqVrOdzFeYs84yU6zY9uiof1UTI2R2ATdI/pECCA=="
+        "requested": "[4.2.2, 4.2.2]",
+        "resolved": "4.2.2",
+        "contentHash": "8JPEP2eGA1inwYmq0lBmZnVR/Y9UQg+ILcnVnk/fZf07tzfIxJhuovZXaXuLT2qby02kEUihXno7YnSfA2NIEA=="
       },
       "Microsoft.Owin.Security.OAuth": {
         "type": "Direct",
-        "requested": "[4.2.0, 4.2.0]",
-        "resolved": "4.2.0",
-        "contentHash": "aMHGnSrCqFyS3a5mwiTx0isrxXoYvi3Xt4KDjj00zswFhb9EmjfJL6EmP6WuopefixdMpNQGJ5XQjT+qtBd5lA=="
+        "requested": "[4.2.2, 4.2.2]",
+        "resolved": "4.2.2",
+        "contentHash": "Y0F0lmDZAdpQn9LMdVwfWwq5JZpLu2OYSdToVwMdneC1AAVvaPxkFW6gnMe1Uox2ZNJwFd8Ytt1lm4eQL7itqw=="
       },
       "Microsoft.Owin.Security.Twitter": {
         "type": "Direct",
-        "requested": "[4.2.0, 4.2.0]",
-        "resolved": "4.2.0",
-        "contentHash": "d+w5iroY1w9FQBDJL0KzEXIl44YrCoBqgmIyDt4cdwWA4C85U+4AwZn4Pqmlj0S3tPyoPTqbpiDxMDWdfqbJ1A=="
+        "requested": "[4.2.2, 4.2.2]",
+        "resolved": "4.2.2",
+        "contentHash": "f4LRCXQbODqyhoDy/dk5Yx8CSl5QCokPgJfWcqjohMTGJsQ3fRUMv6UECtNe47avwIvltJap5mzWm+Ps24F0ew=="
       },
       "Microsoft.Web.Infrastructure": {
         "type": "Direct",

--- a/examples/Identity/packages.lock.json
+++ b/examples/Identity/packages.lock.json
@@ -76,9 +76,9 @@
       },
       "Microsoft.AspNetCore.Http": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "pPDcCW8spnyibK3krpxrOpaFHf5fjV6k1Hsl6gfh77N/8gRYlLU7MOQDUnjpEwdlHmtxwJKQJNxZqVQOmJGRUw=="
+        "requested": "[2.1.34, 2.1.34]",
+        "resolved": "2.1.34",
+        "contentHash": "d1U34fyniRrDW0SD7KryDhXq1KWEjeE1XuLgk/qcdFHUjkjY6XztmhEmQJicGlPYKEZOe+3UMWz5EZChLwnrvQ=="
       },
       "Microsoft.AspNetCore.Http.Abstractions": {
         "type": "Direct",
@@ -88,9 +88,9 @@
       },
       "Microsoft.AspNetCore.Http.Extensions": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "ncAgV+cqsWSqjLXFUTyObGh4Tr7ShYYs3uW8Q/YpRwZn7eLV7dux5Z6GLY+rsdzmIHiia3Q2NWbLULQi7aziHw=="
+        "requested": "[2.1.21, 2.1.21]",
+        "resolved": "2.1.21",
+        "contentHash": "+T9PPrE/ZHB+jEe1a79hoWu6p87XiU/BJ3uoasjH/rPR88zk8dWO9KwE8A2zZi81UEDusAk2H8q7s/K2teRo9A=="
       },
       "Microsoft.AspNetCore.Http.Features": {
         "type": "Direct",
@@ -130,9 +130,9 @@
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "fcLCTS03poWE4v9tSNBr3pWn0QwGgAn1vzqHXlXgvqZeOc7LvQNzaWcKRQZTdEc3+YhQKwMsOtm3VKSA2aWQ8w=="
+        "requested": "[2.1.10, 2.1.10]",
+        "resolved": "2.1.10",
+        "contentHash": "anSrDPFjcz6oBQjrul2vSHCg/wOZ2gJc1ZNzm03LtkA9S17x8xnkLaT599uuFnl6JSZJgQy4hoHVzt2+bIDc9w=="
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
         "type": "Direct",
@@ -220,9 +220,9 @@
       },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "SErON45qh4ogDp6lr6UvVmFYW0FERihW+IQ+2JyFv1PUyWktcJytFaWH5zarufJvZwhci7Rf1IyGXr9pVEadTw=="
+        "requested": "[2.1.6, 2.1.6]",
+        "resolved": "2.1.6",
+        "contentHash": "4Xva9hlVx/2zv5bUr9QlPSCQBh5MwVkMoJ8jd9lgHNgx2C2Ol35/0KZrNsmKffcaKjb+Bj6btBq1QjPozhqTPQ=="
       },
       "Microsoft.Extensions.Options": {
         "type": "Direct",
@@ -238,9 +238,9 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "scJ1GZNIxMmjpENh0UZ8XCQ6vzr/LzeF9WvEA51Ix2OQGAs9WPgPu8ABVUdvpKPLuor/t05gm6menJK3PwqOXg=="
+        "requested": "[2.1.6, 2.1.6]",
+        "resolved": "2.1.6",
+        "contentHash": "uf0zvl2v/OoDUkz9JnPi1z4B2YbjkgN+pyOKoWD/qwB3ytYoAHFg03rTZ9K8pLdjp/YQlH5B2gY0Li8vrLYNQw=="
       },
       "Microsoft.jQuery.Unobtrusive.Validation": {
         "type": "Direct",
@@ -250,9 +250,9 @@
       },
       "Microsoft.Net.Http.Headers": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "lPNIphl8b2EuhOE9dMH6EZDmu7pS882O+HMi5BJNsigxHaWlBrYxZHFZgE18cyaPp6SSZcTkKkuzfjV/RRQKlA=="
+        "requested": "[2.1.14, 2.1.14]",
+        "resolved": "2.1.14",
+        "contentHash": "+45BYzxrBr0Pqc9B/9EhX/KvlGqe0PrB+WgJW8ZrGmoyIMMs8aObPfgZbALpjN0VOq1/WYy1y5RcEOw53MRuMg=="
       },
       "Microsoft.Owin": {
         "type": "Direct",
@@ -334,9 +334,9 @@
       },
       "System.Buffers": {
         "type": "Direct",
-        "requested": "[4.5.0, 4.5.0]",
-        "resolved": "4.5.0",
-        "contentHash": "pL2ChpaRRWI/p4LXyy4RgeWlYF2sgfj/pnVMvBqwNFr5cXg7CXNnWZWxrOONLg8VGdFB8oB+EG2Qw4MLgTOe+A=="
+        "requested": "[4.5.1, 4.5.1]",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
       },
       "System.Collections.Immutable": {
         "type": "Direct",
@@ -352,15 +352,15 @@
       },
       "System.Memory": {
         "type": "Direct",
-        "requested": "[4.5.1, 4.5.1]",
-        "resolved": "4.5.1",
-        "contentHash": "sDJYJpGtTgx+23Ayu5euxG5mAXWdkDb4+b0rD0Cab0M1oQS9H0HXGPriKcqpXuiJDTV7fTp/d+fMDJmnr6sNvA=="
+        "requested": "[4.5.5, 4.5.5]",
+        "resolved": "4.5.5",
+        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw=="
       },
       "System.Numerics.Vectors": {
         "type": "Direct",
-        "requested": "[4.4.0, 4.4.0]",
-        "resolved": "4.4.0",
-        "contentHash": "UiLzLW+Lw6HLed1Hcg+8jSRttrbuXv7DANVj0DkL9g6EnnzbL75EB7EWsw5uRbhxd/4YdG8li5XizGWepmG3PQ=="
+        "requested": "[4.5.0, 4.5.0]",
+        "resolved": "4.5.0",
+        "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
       },
       "System.Reflection.Metadata": {
         "type": "Direct",
@@ -370,15 +370,15 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Direct",
-        "requested": "[4.5.1, 4.5.1]",
-        "resolved": "4.5.1",
-        "contentHash": "Zh8t8oqolRaFa9vmOZfdQm/qKejdqz0J9kr7o2Fu0vPeoH3BL1EOXipKWwkWtLT1JPzjByrF19fGuFlNbmPpiw=="
+        "requested": "[4.5.3, 4.5.3]",
+        "resolved": "4.5.3",
+        "contentHash": "3TIsJhD1EiiT0w2CcDMN/iSSwnNnsrnbzeVHSKkaEgV85txMprmuO+Yq2AdSbeVGcg28pdNDTPK87tJhX7VFHw=="
       },
       "System.Text.Encodings.Web": {
         "type": "Direct",
-        "requested": "[4.5.0, 4.5.0]",
-        "resolved": "4.5.0",
-        "contentHash": "Xg4G4Indi4dqP1iuAiMSwpiWS54ZghzR644OtsRCm/m/lBMG8dUBhLVN7hLm8NNrNTR+iGbshCPTwrvxZPlm4g=="
+        "requested": "[4.5.1, 4.5.1]",
+        "resolved": "4.5.1",
+        "contentHash": "8lfETN/1lu0QD+XQaDCxn6InX3KYJHCFO6Iqrm92zn9eOEeonTuyisKxW0nLZfse598LibhEItiRdPzVn8Beyg=="
       },
       "WebGrease": {
         "type": "Direct",

--- a/examples/Identity/packages.lock.json
+++ b/examples/Identity/packages.lock.json
@@ -346,9 +346,9 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Direct",
-        "requested": "[4.5.0, 4.5.0]",
-        "resolved": "4.5.0",
-        "contentHash": "eIHRELiYDQvsMToML81QFkXEEYXUSUT2F28t1SGrevWqP+epFdw80SyAXIKTXOHrIEXReFOEnEr7XlGiC2GgOg=="
+        "requested": "[4.5.1, 4.5.1]",
+        "resolved": "4.5.1",
+        "contentHash": "zCno/m44ymWhgLFh7tELDG9587q0l/EynPM0m4KgLaWQbz/TEKvNRX2YT5ip2qXW/uayifQ2ZqbnErsKJ4lYrQ=="
       },
       "System.Memory": {
         "type": "Direct",

--- a/examples/Identity/packages.lock.json
+++ b/examples/Identity/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "EntityFramework": {
         "type": "Direct",
-        "requested": "[6.2.0, 6.2.0]",
-        "resolved": "6.2.0",
-        "contentHash": "ptGyXOf26qLrtn+2doAmylIlCxOnBJANwlyyLrXDmqIk9O18IzLWHyxDwwAyhgXkxmbiaA0WNpRy67WRReInBw=="
+        "requested": "[6.4.4, 6.4.4]",
+        "resolved": "6.4.4",
+        "contentHash": "yj1+/4tci7Panu3jKDHYizxwVm0Jvm7b7m057b5h4u8NUHGCR8WIWirBTw+8EptRffwftIWPBeIRGNKD1ewEMQ=="
       },
       "Microsoft.AspNet.Identity.Core": {
         "type": "Direct",

--- a/examples/Identity/packages.lock.json
+++ b/examples/Identity/packages.lock.json
@@ -322,9 +322,9 @@
       },
       "Newtonsoft.Json": {
         "type": "Direct",
-        "requested": "[12.0.2, 12.0.2]",
-        "resolved": "12.0.2",
-        "contentHash": "rTK0s2EKlfHsQsH6Yx2smvcTCeyoDNgCW7FEYyV01drPlh2T243PR2DiDXqtC5N4GDm4Ma/lkxfW5a/4793vbA=="
+        "requested": "[13.0.3, 13.0.3]",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "Owin": {
         "type": "Direct",

--- a/examples/Identity/packages.lock.json
+++ b/examples/Identity/packages.lock.json
@@ -310,9 +310,9 @@
       },
       "Microsoft.Web.Infrastructure": {
         "type": "Direct",
-        "requested": "[1.0.0, 1.0.0]",
-        "resolved": "1.0.0",
-        "contentHash": "FNmvLn5m2LTU/Rs2KWVo0SIIh9Ek+U0ojex7xeDaSHw/zgEP77A8vY5cVWgUtBGS8MJfDGNn8rpXJWEIQaPwTg=="
+        "requested": "[2.0.0, 2.0.0]",
+        "resolved": "2.0.0",
+        "contentHash": "NA6F00drSYd4HZk7QcyMRz1EEdZQQpcdnt6DfNiurNcUNsmmRDpz9db2Bc3L3Lgo455BOSwNDuNjbhDLltKGKQ=="
       },
       "MSBuild.Microsoft.VisualStudio.Web.targets": {
         "type": "Direct",

--- a/examples/Web/UnravelExamples.Web.csproj
+++ b/examples/Web/UnravelExamples.Web.csproj
@@ -280,6 +280,9 @@
     <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Owin.Host.SystemWeb.4.2.2\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Web.Infrastructure, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Web.Infrastructure.2.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Win32.Registry, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Win32.Registry.4.5.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
@@ -490,10 +493,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web.Services" />
-    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
     <Reference Include="System.Net.Http">
     </Reference>
     <Reference Include="System.Net.Http.WebRequest">

--- a/examples/Web/UnravelExamples.Web.csproj
+++ b/examples/Web/UnravelExamples.Web.csproj
@@ -284,11 +284,10 @@
       <HintPath>..\..\packages\Microsoft.Win32.Registry.4.5.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json.Bson, Version=1.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.Bson.1.0.1\lib\net45\Newtonsoft.Json.Bson.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.Bson.1.0.2\lib\net45\Newtonsoft.Json.Bson.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/examples/Web/UnravelExamples.Web.csproj
+++ b/examples/Web/UnravelExamples.Web.csproj
@@ -171,11 +171,11 @@
     <Reference Include="Microsoft.AspNetCore.WebUtilities, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.WebUtilities.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.WebUtilities.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.8.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=3.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.3.4.0\lib\netstandard2.0\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.2.8.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=3.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.3.4.0\lib\netstandard2.0\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Razor, Version=2.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Razor.2.1.2\lib\net46\Microsoft.CodeAnalysis.Razor.dll</HintPath>
@@ -308,8 +308,8 @@
       <HintPath>..\..\packages\System.ComponentModel.Annotations.4.5.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+    <Reference Include="System.Console, Version=4.0.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Console.4.3.1\lib\net46\System.Console.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
@@ -378,16 +378,16 @@
     <Reference Include="System.Reflection.Metadata, Version=1.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reflection.Metadata.1.6.0\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+    <Reference Include="System.Runtime, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.4.3.1\lib\net462\System.Runtime.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.Extensions.4.3.0\lib\net462\System.Runtime.Extensions.dll</HintPath>
+    <Reference Include="System.Runtime.Extensions, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.Extensions.4.3.1\lib\net462\System.Runtime.Extensions.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
@@ -406,7 +406,7 @@
       <HintPath>..\..\packages\System.Security.AccessControl.4.5.0\lib\net461\System.Security.AccessControl.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.3.1\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
@@ -420,8 +420,8 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
@@ -435,8 +435,8 @@
       <HintPath>..\..\packages\System.Security.Principal.Windows.4.5.1\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
     <Reference Include="System.ServiceProcess" />
-    <Reference Include="System.Text.Encoding.CodePages, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Text.Encoding.CodePages.4.3.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
+    <Reference Include="System.Text.Encoding.CodePages, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Text.Encoding.CodePages.4.5.1\lib\net461\System.Text.Encoding.CodePages.dll</HintPath>
     </Reference>
     <Reference Include="System.Text.Encodings.Web, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Text.Encodings.Web.4.5.1\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
@@ -502,7 +502,7 @@
       <HintPath>..\..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+      <HintPath>..\..\packages\System.Xml.ReaderWriter.4.3.1\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
@@ -609,8 +609,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
-    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.3.3.4\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/examples/Web/UnravelExamples.Web.csproj
+++ b/examples/Web/UnravelExamples.Web.csproj
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\packages\MSBuild.Microsoft.VisualStudio.Web.targets.14.0.0.3\build\MSBuild.Microsoft.VisualStudio.Web.targets.props" Condition="Exists('..\..\packages\MSBuild.Microsoft.VisualStudio.Web.targets.14.0.0.3\build\MSBuild.Microsoft.VisualStudio.Web.targets.props')" />
+  <Import Project="..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.2\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.props" Condition="Exists('..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.2\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.props')" />
+  <Import Project="..\..\packages\Microsoft.AspNetCore.Razor.Design.2.1.2\build\netstandard2.0\Microsoft.AspNetCore.Razor.Design.props" Condition="Exists('..\..\packages\Microsoft.AspNetCore.Razor.Design.2.1.2\build\netstandard2.0\Microsoft.AspNetCore.Razor.Design.props')" />
   <Import Project="..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets" Condition="Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" />
-  <Import Project="..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.props" Condition="Exists('..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.props')" />
   <Import Project="..\..\packages\Microsoft.DiaSymReader.Native.1.7.0\build\Microsoft.DiaSymReader.Native.props" Condition="Exists('..\..\packages\Microsoft.DiaSymReader.Native.1.7.0\build\Microsoft.DiaSymReader.Native.props')" />
-  <Import Project="..\..\packages\Microsoft.AspNetCore.Razor.Design.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Razor.Design.props" Condition="Exists('..\..\packages\Microsoft.AspNetCore.Razor.Design.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Razor.Design.props')" />
   <Import Project="..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.props" Condition="Exists('..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -60,11 +60,11 @@
     <Reference Include="Microsoft.AspNetCore.Authentication.Core, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Authentication.Core.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Authentication.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Authorization, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNetCore.Authorization.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Authorization.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Authorization, Version=2.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Authorization.2.1.2\lib\netstandard2.0\Microsoft.AspNetCore.Authorization.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Authorization.Policy, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNetCore.Authorization.Policy.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Authorization.Policy.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Authorization.Policy, Version=2.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Authorization.Policy.2.1.2\lib\netstandard2.0\Microsoft.AspNetCore.Authorization.Policy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Cors, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Cors.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Cors.dll</HintPath>
@@ -93,14 +93,14 @@
     <Reference Include="Microsoft.AspNetCore.Html.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Html.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Html.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Http, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNetCore.Http.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Http.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Http, Version=2.1.34.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Http.2.1.34\lib\netstandard2.0\Microsoft.AspNetCore.Http.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Http.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Http.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Http.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Http.Extensions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNetCore.Http.Extensions.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Http.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Http.Extensions, Version=2.1.21.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Http.Extensions.2.1.21\lib\netstandard2.0\Microsoft.AspNetCore.Http.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Http.Features, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Http.Features.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Http.Features.dll</HintPath>
@@ -114,14 +114,14 @@
     <Reference Include="Microsoft.AspNetCore.Mvc, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Mvc.Abstractions, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Abstractions.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Mvc.Abstractions, Version=2.1.38.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Abstractions.2.1.38\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Mvc.ApiExplorer, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.ApiExplorer.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.ApiExplorer.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Mvc.Core, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Core.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.Core.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Mvc.Core, Version=2.1.38.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Core.2.1.38\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Mvc.Cors, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Cors.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.Cors.dll</HintPath>
@@ -129,8 +129,8 @@
     <Reference Include="Microsoft.AspNetCore.Mvc.DataAnnotations, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.DataAnnotations.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.DataAnnotations.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Mvc.Formatters.Json, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Formatters.Json.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.Formatters.Json.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Mvc.Formatters.Json, Version=2.1.18.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Formatters.Json.2.1.18\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.Formatters.Json.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Mvc.Localization, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Localization.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.Localization.dll</HintPath>
@@ -138,11 +138,11 @@
     <Reference Include="Microsoft.AspNetCore.Mvc.Razor, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Razor.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\lib\net46\Microsoft.AspNetCore.Mvc.Razor.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions, Version=2.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.2\lib\net46\Microsoft.AspNetCore.Mvc.Razor.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Mvc.RazorPages, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.RazorPages.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.RazorPages.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Mvc.RazorPages, Version=2.1.11.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.RazorPages.2.1.11\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.RazorPages.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Mvc.TagHelpers, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.TagHelpers.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.TagHelpers.dll</HintPath>
@@ -150,14 +150,14 @@
     <Reference Include="Microsoft.AspNetCore.Mvc.ViewFeatures, Version=2.1.3.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.Mvc.ViewFeatures.2.1.3\lib\netstandard2.0\Microsoft.AspNetCore.Mvc.ViewFeatures.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Razor, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNetCore.Razor.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Razor.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Razor, Version=2.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Razor.2.1.2\lib\netstandard2.0\Microsoft.AspNetCore.Razor.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Razor.Language, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNetCore.Razor.Language.2.1.1\lib\net46\Microsoft.AspNetCore.Razor.Language.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Razor.Language, Version=2.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Razor.Language.2.1.2\lib\net46\Microsoft.AspNetCore.Razor.Language.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Razor.Runtime, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNetCore.Razor.Runtime.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.Razor.Runtime.dll</HintPath>
+    <Reference Include="Microsoft.AspNetCore.Razor.Runtime, Version=2.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNetCore.Razor.Runtime.2.1.2\lib\netstandard2.0\Microsoft.AspNetCore.Razor.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.ResponseCaching.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNetCore.ResponseCaching.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.AspNetCore.ResponseCaching.Abstractions.dll</HintPath>
@@ -177,8 +177,8 @@
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.2.8.0\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Razor, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Razor.2.1.1\lib\net46\Microsoft.CodeAnalysis.Razor.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.Razor, Version=2.1.2.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Razor.2.1.2\lib\net46\Microsoft.CodeAnalysis.Razor.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\lib\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
@@ -187,11 +187,11 @@
     <Reference Include="Microsoft.DotNet.PlatformAbstractions, Version=2.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.DotNet.PlatformAbstractions.2.1.0\lib\net45\Microsoft.DotNet.PlatformAbstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Caching.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.Caching.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Caching.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Caching.Abstractions, Version=2.1.23.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Caching.Abstractions.2.1.23\lib\netstandard2.0\Microsoft.Extensions.Caching.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Caching.Memory, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.Caching.Memory.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Caching.Memory.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Caching.Memory, Version=2.1.23.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Caching.Memory.2.1.23\lib\netstandard2.0\Microsoft.Extensions.Caching.Memory.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Configuration, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Configuration.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll</HintPath>
@@ -199,8 +199,8 @@
     <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Binder.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=2.1.10.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Configuration.Binder.2.1.10\lib\netstandard2.0\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
@@ -256,8 +256,8 @@
     <Reference Include="Microsoft.Extensions.Logging.Debug, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Logging.Debug.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Logging.Debug.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.ObjectPool, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.ObjectPool.2.1.1\lib\netstandard2.0\Microsoft.Extensions.ObjectPool.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.ObjectPool, Version=2.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.ObjectPool.2.1.6\lib\netstandard2.0\Microsoft.Extensions.ObjectPool.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Options, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Options.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
@@ -265,14 +265,14 @@
     <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Extensions.Primitives.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=2.1.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Primitives.2.1.6\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.WebEncoders, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Extensions.WebEncoders.2.1.1\lib\netstandard2.0\Microsoft.Extensions.WebEncoders.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Net.Http.Headers, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Net.Http.Headers.2.1.1\lib\netstandard2.0\Microsoft.Net.Http.Headers.dll</HintPath>
+    <Reference Include="Microsoft.Net.Http.Headers, Version=2.1.14.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Net.Http.Headers.2.1.14\lib\netstandard2.0\Microsoft.Net.Http.Headers.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Owin.4.2.2\lib\net45\Microsoft.Owin.dll</HintPath>
@@ -299,7 +299,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+      <HintPath>..\..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
@@ -359,16 +359,16 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Memory.4.5.1\lib\netstandard2.0\System.Memory.dll</HintPath>
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.9\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
     <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
@@ -383,8 +383,8 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.1\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Runtime.Extensions.4.3.0\lib\net462\System.Runtime.Extensions.dll</HintPath>
@@ -431,18 +431,18 @@
     <Reference Include="System.Security.Permissions, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Security.Permissions.4.5.0\lib\net461\System.Security.Permissions.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Principal.Windows, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Security.Principal.Windows.4.5.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Principal.Windows.4.5.1\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Text.Encoding.CodePages, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Text.Encoding.CodePages.4.3.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Text.Encodings.Web.4.5.0\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Text.Encodings.Web.4.5.1\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
@@ -450,10 +450,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Transactions" />
-    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-      <Private>True</Private>
-      <Private>True</Private>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
@@ -656,14 +654,14 @@
     <Error Condition="!Exists('..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.4.1.0\build\net472\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.targets'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.AspNetCore.Razor.Design.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Razor.Design.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.AspNetCore.Razor.Design.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Razor.Design.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.DiaSymReader.Native.1.7.0\build\Microsoft.DiaSymReader.Native.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.DiaSymReader.Native.1.7.0\build\Microsoft.DiaSymReader.Native.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.props'))" />
-    <Error Condition="!Exists('..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.targets'))" />
     <Error Condition="!Exists('..\..\packages\MSBuild.Microsoft.VisualStudio.Web.targets.14.0.0.3\build\MSBuild.Microsoft.VisualStudio.Web.targets.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSBuild.Microsoft.VisualStudio.Web.targets.14.0.0.3\build\MSBuild.Microsoft.VisualStudio.Web.targets.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.AspNetCore.Razor.Design.2.1.2\build\netstandard2.0\Microsoft.AspNetCore.Razor.Design.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.AspNetCore.Razor.Design.2.1.2\build\netstandard2.0\Microsoft.AspNetCore.Razor.Design.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.2\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.2\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.2\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.2\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.targets'))" />
   </Target>
   <Import Project="..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.targets" Condition="Exists('..\..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.1.1\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.targets')" />
-  <Import Project="..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.targets" Condition="Exists('..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.1\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.targets')" />
+  <Import Project="..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.2\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.targets" Condition="Exists('..\..\packages\Microsoft.AspNetCore.Mvc.Razor.Extensions.2.1.2\build\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.Extensions.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/examples/Web/Web.config
+++ b/examples/Web/Web.config
@@ -180,6 +180,10 @@
         <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.4.0.0" newVersion="3.4.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Web.Infrastructure" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.codedom>

--- a/examples/Web/Web.config
+++ b/examples/Web/Web.config
@@ -168,6 +168,18 @@
         <assemblyIdentity name="System.Security.Principal.Windows" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.1" newVersion="4.1.1.1" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.4.0.0" newVersion="3.4.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.4.0.0" newVersion="3.4.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.codedom>

--- a/examples/Web/Web.config
+++ b/examples/Web/Web.config
@@ -76,6 +76,98 @@
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="1.0.0.0-5.2.9.0" newVersion="5.2.9.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.AspNetCore.Http" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.34.0" newVersion="2.1.34.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.AspNetCore.Authorization" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.2.0" newVersion="2.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.AspNetCore.Authorization.Policy" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.2.0" newVersion="2.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.ObjectPool" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.6.0" newVersion="2.1.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.6.0" newVersion="2.1.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.1" newVersion="4.0.3.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.AspNetCore.Http.Extensions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.21.0" newVersion="2.1.21.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.AspNetCore.Mvc.Core" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.38.0" newVersion="2.1.38.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.AspNetCore.Mvc.RazorPages" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.11.0" newVersion="2.1.11.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.AspNetCore.Mvc.Formatters.Json" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.18.0" newVersion="2.1.18.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.AspNetCore.Mvc.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.38.0" newVersion="2.1.38.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.AspNetCore.Razor" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.2.0" newVersion="2.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.AspNetCore.Razor.Runtime" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.2.0" newVersion="2.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.AspNetCore.Razor.Language" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.2.0" newVersion="2.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Caching.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.23.0" newVersion="2.1.23.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.CodeAnalysis.Razor" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.2.0" newVersion="2.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Caching.Memory" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.23.0" newVersion="2.1.23.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.AspNetCore.Mvc.Razor.Extensions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.2.0" newVersion="2.1.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.10.0" newVersion="2.1.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Net.Http.Headers" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.14.0" newVersion="2.1.14.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Principal.Windows" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.1" newVersion="4.1.1.1" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.codedom>

--- a/examples/Web/packages.config
+++ b/examples/Web/packages.config
@@ -89,7 +89,7 @@
   <package id="Microsoft.Net.Http.Headers" version="2.1.14" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Owin" version="4.2.2" targetFramework="net472" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="4.2.2" targetFramework="net472" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
+  <package id="Microsoft.Web.Infrastructure" version="2.0.0" targetFramework="net472" />
   <package id="Microsoft.Win32.Registry" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="MSBuild.Microsoft.VisualStudio.Web.targets" version="14.0.0.3" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />

--- a/examples/Web/packages.config
+++ b/examples/Web/packages.config
@@ -92,8 +92,8 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
   <package id="Microsoft.Win32.Registry" version="4.5.0" targetFramework="net472" />
   <package id="MSBuild.Microsoft.VisualStudio.Web.targets" version="14.0.0.3" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
-  <package id="Newtonsoft.Json.Bson" version="1.0.1" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
+  <package id="Newtonsoft.Json.Bson" version="1.0.2" targetFramework="net472" />
   <package id="Owin" version="1.0" targetFramework="net472" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net472" />

--- a/examples/Web/packages.config
+++ b/examples/Web/packages.config
@@ -9,84 +9,84 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.9" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.9" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.9" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Antiforgery" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Authentication.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Authentication.Core" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Authorization" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Authorization.Policy" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Cors" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Cryptography.Internal" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.DataProtection" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.DataProtection.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Diagnostics.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Hosting" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Hosting.Server.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Html.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http.Extensions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http.Features" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.JsonPatch" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Localization" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc" version="2.1.3" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc.Abstractions" version="2.1.3" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc.ApiExplorer" version="2.1.3" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc.Core" version="2.1.3" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc.Cors" version="2.1.3" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc.DataAnnotations" version="2.1.3" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc.Formatters.Json" version="2.1.3" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc.Localization" version="2.1.3" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc.Razor" version="2.1.3" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc.Razor.Extensions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc.RazorPages" version="2.1.3" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc.TagHelpers" version="2.1.3" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc.ViewFeatures" version="2.1.3" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Razor" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Razor.Design" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Razor.Language" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Razor.Runtime" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.ResponseCaching.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Routing" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Routing.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.WebUtilities" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Antiforgery" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Authentication.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Authentication.Core" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Authorization" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Authorization.Policy" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Cors" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Cryptography.Internal" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.DataProtection" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.DataProtection.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Diagnostics.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Hosting" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Hosting.Server.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Html.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Extensions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Features" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.JsonPatch" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Localization" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Abstractions" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.ApiExplorer" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Core" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Cors" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.DataAnnotations" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Formatters.Json" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Localization" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Razor" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Razor.Extensions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.RazorPages" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.TagHelpers" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.ViewFeatures" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Razor" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Razor.Design" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Razor.Language" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Razor.Runtime" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.ResponseCaching.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Routing" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Routing.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.WebUtilities" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net472" />
   <package id="Microsoft.CodeAnalysis.Common" version="2.8.0" targetFramework="net472" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="2.8.0" targetFramework="net472" />
-  <package id="Microsoft.CodeAnalysis.Razor" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.CodeAnalysis.Razor" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="4.1.0" targetFramework="net472" />
-  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net472" />
+  <package id="Microsoft.CSharp" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="Microsoft.DiaSymReader.Native" version="1.7.0" targetFramework="net472" />
-  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.1.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Caching.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Caching.Memory" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.Binder" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.FileExtensions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.Json" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.UserSecrets" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.DependencyModel" version="2.1.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.FileProviders.Composite" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.FileProviders.Physical" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.FileSystemGlobbing" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Hosting.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Localization" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Localization.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Logging" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Logging.Configuration" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Logging.Debug" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.ObjectPool" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Options" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Primitives" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Extensions.WebEncoders" version="2.1.1" targetFramework="net472" />
-  <package id="Microsoft.Net.Http.Headers" version="2.1.1" targetFramework="net472" />
+  <package id="Microsoft.DotNet.PlatformAbstractions" version="2.1.0" allowedVersions="[2.1.0,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Caching.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Caching.Memory" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.FileExtensions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Json" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.UserSecrets" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyModel" version="2.1.0" allowedVersions="[2.1.0,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.FileProviders.Composite" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.FileProviders.Physical" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.FileSystemGlobbing" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Localization" version="2.1.1" allowedVersions="[2.1.1,2.2.0)"  targetFramework="net472" />
+  <package id="Microsoft.Extensions.Localization.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)"  targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging.Configuration" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging.Debug" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.ObjectPool" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Options" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Primitives" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.WebEncoders" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Net.Http.Headers" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Owin" version="4.2.2" targetFramework="net472" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="4.2.2" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
@@ -96,14 +96,14 @@
   <package id="Newtonsoft.Json.Bson" version="1.0.2" targetFramework="net472" />
   <package id="Owin" version="1.0" targetFramework="net472" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net472" />
-  <package id="System.Buffers" version="4.5.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="System.Collections" version="4.3.0" targetFramework="net472" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net472" />
-  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net472" />
-  <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net472" />
+  <package id="System.Collections.Immutable" version="1.5.0" allowedVersions="[1.5.0,1.6.0)" targetFramework="net472" />
+  <package id="System.ComponentModel.Annotations" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="System.Console" version="4.3.0" targetFramework="net472" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net472" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net472" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
   <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net472" />
   <package id="System.Diagnostics.StackTrace" version="4.3.0" targetFramework="net472" />
   <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net472" />
@@ -115,13 +115,13 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net472" />
   <package id="System.Linq" version="4.3.0" targetFramework="net472" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net472" />
-  <package id="System.Memory" version="4.5.1" targetFramework="net472" />
-  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.1" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.4.0" allowedVersions="[4.4.0,4.6.0)" targetFramework="net472" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net472" />
-  <package id="System.Reflection.Metadata" version="1.6.0" targetFramework="net472" />
+  <package id="System.Reflection.Metadata" version="1.6.0" allowedVersions="[1.6.0,1.7.0)" targetFramework="net472" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net472" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net472" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net472" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net472" />
@@ -137,13 +137,13 @@
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net472" />
   <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net472" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="4.5.0" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="System.Threading" version="4.3.0" targetFramework="net472" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net472" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net472" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net472" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.3.0" allowedVersions="[4.3.0,4.6.0)" targetFramework="net472" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net472" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net472" />
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net472" />

--- a/examples/Web/packages.config
+++ b/examples/Web/packages.config
@@ -90,7 +90,7 @@
   <package id="Microsoft.Owin" version="4.2.2" targetFramework="net472" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="4.2.2" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
-  <package id="Microsoft.Win32.Registry" version="4.5.0" targetFramework="net472" />
+  <package id="Microsoft.Win32.Registry" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="MSBuild.Microsoft.VisualStudio.Web.targets" version="14.0.0.3" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
   <package id="Newtonsoft.Json.Bson" version="1.0.2" targetFramework="net472" />
@@ -126,14 +126,14 @@
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net472" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net472" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net472" />
-  <package id="System.Security.AccessControl" version="4.5.0" targetFramework="net472" />
+  <package id="System.Security.AccessControl" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net472" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net472" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net472" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net472" />
-  <package id="System.Security.Cryptography.Xml" version="4.5.0" targetFramework="net472" />
-  <package id="System.Security.Permissions" version="4.5.0" targetFramework="net472" />
-  <package id="System.Security.Principal.Windows" version="4.5.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Xml" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
+  <package id="System.Security.Permissions" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
+  <package id="System.Security.Principal.Windows" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net472" />
   <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net472" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net472" />

--- a/examples/Web/packages.config
+++ b/examples/Web/packages.config
@@ -12,8 +12,8 @@
   <package id="Microsoft.AspNetCore.Antiforgery" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Authentication.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Authentication.Core" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Authorization" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Authorization.Policy" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Authorization" version="2.1.2" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Authorization.Policy" version="2.1.2" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Cors" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Cryptography.Internal" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.DataProtection" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
@@ -23,29 +23,29 @@
   <package id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Hosting.Server.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Html.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http" version="2.1.34" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Http.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http.Extensions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Extensions" version="2.1.21" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Http.Features" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.JsonPatch" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Localization" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Mvc" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc.Abstractions" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Abstractions" version="2.1.38" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Mvc.ApiExplorer" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc.Core" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Core" version="2.1.38" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Mvc.Cors" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Mvc.DataAnnotations" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc.Formatters.Json" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Formatters.Json" version="2.1.18" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Mvc.Localization" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Mvc.Razor" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc.Razor.Extensions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Mvc.RazorPages" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.Razor.Extensions" version="2.1.2" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Mvc.RazorPages" version="2.1.11" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Mvc.TagHelpers" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Mvc.ViewFeatures" version="2.1.3" allowedVersions="[2.1.3,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Razor" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Razor.Design" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Razor.Language" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Razor.Runtime" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Razor" version="2.1.2" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Razor.Design" version="2.1.2" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Razor.Language" version="2.1.2" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Razor.Runtime" version="2.1.2" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.ResponseCaching.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Routing" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Routing.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
@@ -53,16 +53,16 @@
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net472" />
   <package id="Microsoft.CodeAnalysis.Common" version="2.8.0" targetFramework="net472" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="2.8.0" targetFramework="net472" />
-  <package id="Microsoft.CodeAnalysis.Razor" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.CodeAnalysis.Razor" version="2.1.2" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="4.1.0" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="Microsoft.DiaSymReader.Native" version="1.7.0" targetFramework="net472" />
   <package id="Microsoft.DotNet.PlatformAbstractions" version="2.1.0" allowedVersions="[2.1.0,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Caching.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Caching.Memory" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Caching.Abstractions" version="2.1.23" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Caching.Memory" version="2.1.23" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Configuration" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.Binder" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="2.1.10" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Configuration.FileExtensions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Configuration.Json" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
@@ -75,18 +75,18 @@
   <package id="Microsoft.Extensions.FileProviders.Physical" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.FileSystemGlobbing" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Hosting.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Localization" version="2.1.1" allowedVersions="[2.1.1,2.2.0)"  targetFramework="net472" />
-  <package id="Microsoft.Extensions.Localization.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)"  targetFramework="net472" />
+  <package id="Microsoft.Extensions.Localization" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Localization.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Logging" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Logging.Configuration" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Logging.Debug" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.Extensions.ObjectPool" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.ObjectPool" version="2.1.6" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Options" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Primitives" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Primitives" version="2.1.6" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Extensions.WebEncoders" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.Net.Http.Headers" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
+  <package id="Microsoft.Net.Http.Headers" version="2.1.14" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.Owin" version="4.2.2" targetFramework="net472" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="4.2.2" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
@@ -96,7 +96,7 @@
   <package id="Newtonsoft.Json.Bson" version="1.0.2" targetFramework="net472" />
   <package id="Owin" version="1.0" targetFramework="net472" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net472" />
-  <package id="System.Buffers" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="System.Collections" version="4.3.0" targetFramework="net472" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net472" />
   <package id="System.Collections.Immutable" version="1.5.0" allowedVersions="[1.5.0,1.6.0)" targetFramework="net472" />
@@ -115,13 +115,13 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net472" />
   <package id="System.Linq" version="4.3.0" targetFramework="net472" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net472" />
-  <package id="System.Memory" version="4.5.1" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
-  <package id="System.Numerics.Vectors" version="4.4.0" allowedVersions="[4.4.0,4.6.0)" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.5" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" allowedVersions="[4.4.0,4.6.0)" targetFramework="net472" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net472" />
   <package id="System.Reflection.Metadata" version="1.6.0" allowedVersions="[1.6.0,1.7.0)" targetFramework="net472" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net472" />
   <package id="System.Runtime" version="4.3.0" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.1" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net472" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net472" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net472" />
@@ -133,17 +133,17 @@
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net472" />
   <package id="System.Security.Cryptography.Xml" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="System.Security.Permissions" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
-  <package id="System.Security.Principal.Windows" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
+  <package id="System.Security.Principal.Windows" version="4.5.1" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net472" />
   <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net472" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="4.5.1" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="System.Threading" version="4.3.0" targetFramework="net472" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net472" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.1" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net472" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net472" />
-  <package id="System.ValueTuple" version="4.3.0" allowedVersions="[4.3.0,4.6.0)" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" allowedVersions="[4.3.0,4.6.0)" targetFramework="net472" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net472" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net472" />
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net472" />

--- a/examples/Web/packages.config
+++ b/examples/Web/packages.config
@@ -50,9 +50,9 @@
   <package id="Microsoft.AspNetCore.Routing" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Routing.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.WebUtilities" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net472" />
-  <package id="Microsoft.CodeAnalysis.Common" version="2.8.0" allowedVersions="[2.8.0,3.5.0)" targetFramework="net472" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="2.8.0" allowedVersions="[2.8.0,3.5.0)" targetFramework="net472" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="3.3.4" targetFramework="net472" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.Common" version="3.4.0" allowedVersions="[2.8.0,3.5.0)" targetFramework="net472" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="3.4.0" allowedVersions="[2.8.0,3.5.0)" targetFramework="net472" />
   <package id="Microsoft.CodeAnalysis.Razor" version="2.1.2" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="4.1.0" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
@@ -101,7 +101,7 @@
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net472" />
   <package id="System.Collections.Immutable" version="1.5.0" allowedVersions="[1.5.0,1.6.0)" targetFramework="net472" />
   <package id="System.ComponentModel.Annotations" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
-  <package id="System.Console" version="4.3.0" targetFramework="net472" />
+  <package id="System.Console" version="4.3.1" targetFramework="net472" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net472" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
   <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net472" />
@@ -120,22 +120,22 @@
   <package id="System.Reflection" version="4.3.0" targetFramework="net472" />
   <package id="System.Reflection.Metadata" version="1.6.0" allowedVersions="[1.6.0,1.7.0)" targetFramework="net472" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net472" />
-  <package id="System.Runtime" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime" version="4.3.1" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" allowedVersions="[4.5.1,4.6.0)" targetFramework="net472" />
-  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime.Extensions" version="4.3.1" targetFramework="net472" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net472" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net472" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net472" />
   <package id="System.Security.AccessControl" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net472" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net472" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net472" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net472" />
   <package id="System.Security.Cryptography.Xml" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="System.Security.Permissions" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="System.Security.Principal.Windows" version="4.5.1" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net472" />
-  <package id="System.Text.Encoding.CodePages" version="4.3.0" allowedVersions="[4.3.0,4.6.0)" targetFramework="net472" />
+  <package id="System.Text.Encoding.CodePages" version="4.5.1" allowedVersions="[4.3.0,4.6.0)" targetFramework="net472" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net472" />
   <package id="System.Text.Encodings.Web" version="4.5.1" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="System.Threading" version="4.3.0" targetFramework="net472" />
@@ -144,7 +144,7 @@
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net472" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" allowedVersions="[4.3.0,4.6.0)" targetFramework="net472" />
-  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net472" />
+  <package id="System.Xml.ReaderWriter" version="4.3.1" targetFramework="net472" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net472" />
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net472" />
   <package id="System.Xml.XPath" version="4.3.0" targetFramework="net472" />

--- a/examples/Web/packages.config
+++ b/examples/Web/packages.config
@@ -51,8 +51,8 @@
   <package id="Microsoft.AspNetCore.Routing.Abstractions" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.WebUtilities" version="2.1.1" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net472" />
-  <package id="Microsoft.CodeAnalysis.Common" version="2.8.0" targetFramework="net472" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="2.8.0" targetFramework="net472" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.8.0" allowedVersions="[2.8.0,3.5.0)" targetFramework="net472" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.8.0" allowedVersions="[2.8.0,3.5.0)" targetFramework="net472" />
   <package id="Microsoft.CodeAnalysis.Razor" version="2.1.2" allowedVersions="[2.1.1,2.2.0)" targetFramework="net472" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="4.1.0" targetFramework="net472" />
   <package id="Microsoft.CSharp" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
@@ -135,7 +135,7 @@
   <package id="System.Security.Permissions" version="4.5.0" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="System.Security.Principal.Windows" version="4.5.1" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net472" />
-  <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net472" />
+  <package id="System.Text.Encoding.CodePages" version="4.3.0" allowedVersions="[4.3.0,4.6.0)" targetFramework="net472" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net472" />
   <package id="System.Text.Encodings.Web" version="4.5.1" allowedVersions="[4.5.0,4.6.0)" targetFramework="net472" />
   <package id="System.Threading" version="4.3.0" targetFramework="net472" />

--- a/examples/Web/packages.lock.json
+++ b/examples/Web/packages.lock.json
@@ -556,15 +556,15 @@
       },
       "Newtonsoft.Json": {
         "type": "Direct",
-        "requested": "[13.0.1, 13.0.1]",
-        "resolved": "13.0.1",
-        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+        "requested": "[13.0.3, 13.0.3]",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
       "Newtonsoft.Json.Bson": {
         "type": "Direct",
-        "requested": "[1.0.1, 1.0.1]",
-        "resolved": "1.0.1",
-        "contentHash": "5PYT/IqQ+UK31AmZiSS102R6EsTo+LGTSI8bp7WAUqDKaF4wHXD8U9u4WxTI1vc64tYi++8p3dk3WWNqPFgldw=="
+        "requested": "[1.0.2, 1.0.2]",
+        "resolved": "1.0.2",
+        "contentHash": "QYFyxhaABwmq3p/21VrZNYvCg3DaEoN/wUuw5nmfAf0X3HLjgupwhkEWdgfb9nvGAUIv3osmZoD3kKl4jxEmYQ=="
       },
       "Owin": {
         "type": "Direct",

--- a/examples/Web/packages.lock.json
+++ b/examples/Web/packages.lock.json
@@ -538,9 +538,9 @@
       },
       "Microsoft.Web.Infrastructure": {
         "type": "Direct",
-        "requested": "[1.0.0, 1.0.0]",
-        "resolved": "1.0.0",
-        "contentHash": "FNmvLn5m2LTU/Rs2KWVo0SIIh9Ek+U0ojex7xeDaSHw/zgEP77A8vY5cVWgUtBGS8MJfDGNn8rpXJWEIQaPwTg=="
+        "requested": "[2.0.0, 2.0.0]",
+        "resolved": "2.0.0",
+        "contentHash": "NA6F00drSYd4HZk7QcyMRz1EEdZQQpcdnt6DfNiurNcUNsmmRDpz9db2Bc3L3Lgo455BOSwNDuNjbhDLltKGKQ=="
       },
       "Microsoft.Win32.Registry": {
         "type": "Direct",

--- a/examples/Web/packages.lock.json
+++ b/examples/Web/packages.lock.json
@@ -304,21 +304,21 @@
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Direct",
-        "requested": "[1.1.0, 1.1.0]",
-        "resolved": "1.1.0",
-        "contentHash": "HS3iRWZKcUw/8eZ/08GXKY2Bn7xNzQPzf8gRPHGSowX7u7XXu9i9YEaBeBNKUXWfI7qjvT2zXtLUvbN0hds8vg=="
+        "requested": "[3.3.4, 3.3.4]",
+        "resolved": "3.3.4",
+        "contentHash": "AxkxcPR+rheX0SmvpLVIGLhOUXAKG56a64kV9VQZ4y9gR9ZmPXnqZvHJnmwLSwzrEP6junUF11vuc+aqo5r68g=="
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Direct",
-        "requested": "[2.8.0, 2.8.0]",
-        "resolved": "2.8.0",
-        "contentHash": "06AzG7oOLKTCN1EnoVYL1bQz+Zwa10LMpUn7Kc+PdpN8CQXRqXTyhfxuKIz6t0qWfoatBNXdHD0OLcEYp5pOvQ=="
+        "requested": "[3.4.0, 3.4.0]",
+        "resolved": "3.4.0",
+        "contentHash": "3ncA7cV+iXGA1VYwe2UEZXcvWyZSlbexWjM9AvocP7sik5UD93qt9Hq0fMRGk0jFRmvmE4T2g+bGfXiBVZEhLw=="
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
-        "requested": "[2.8.0, 2.8.0]",
-        "resolved": "2.8.0",
-        "contentHash": "RizcFXuHgGmeuZhxxE1qQdhFA9lGOHlk0MJlCUt6LOnYsevo72gNikPcbANFHY02YK8L/buNrihchY0TroGvXQ=="
+        "requested": "[3.4.0, 3.4.0]",
+        "resolved": "3.4.0",
+        "contentHash": "/LsTtgcMN6Tu1oo7/WYbRAHL4/ubXC/miEakwTpcZKJKtFo7D0AK95Hw0dbGxul6C8WJu60v6NP2435TDYZM+Q=="
       },
       "Microsoft.CodeAnalysis.Razor": {
         "type": "Direct",
@@ -610,9 +610,9 @@
       },
       "System.Console": {
         "type": "Direct",
-        "requested": "[4.3.0, 4.3.0]",
-        "resolved": "4.3.0",
-        "contentHash": "DHDrIxiqk1h03m6khKWV2X8p/uvN79rgSqpilL6uzpmSfxfU5ng8VcPtW4qsDsQDHiTv6IPV9TmD5M/vElPNLg=="
+        "requested": "[4.3.1, 4.3.1]",
+        "resolved": "4.3.1",
+        "contentHash": "6iKDG36vugpW230eBGMLL6GQIx+Buf5txz6DFC1c4MOH8qcOo2mFzId6GsJUTptR4AusnDsdUeCYuzDiftD39w=="
       },
       "System.Diagnostics.Debug": {
         "type": "Direct",
@@ -724,9 +724,9 @@
       },
       "System.Runtime": {
         "type": "Direct",
-        "requested": "[4.3.0, 4.3.0]",
-        "resolved": "4.3.0",
-        "contentHash": "JufQi0vPQ0xGnAczR13AUFglDyVYt4Kqnz1AZaiKZ5+GICq0/1MH/mO/eAJHt/mHW1zjKBJd7kV26SrxddAhiw=="
+        "requested": "[4.3.1, 4.3.1]",
+        "resolved": "4.3.1",
+        "contentHash": "abhfv1dTK6NXOmu4bgHIONxHyEqFjW8HwXPmpY9gmll+ix9UNo4XDcmzJn6oLooftxNssVHdJC1pGT9jkSynQg=="
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Direct",
@@ -736,9 +736,9 @@
       },
       "System.Runtime.Extensions": {
         "type": "Direct",
-        "requested": "[4.3.0, 4.3.0]",
-        "resolved": "4.3.0",
-        "contentHash": "guW0uK0fn5fcJJ1tJVXYd7/1h5F+pea1r7FLSOz/f8vPEqbR2ZAknuRDvTQ8PzAilDveOxNjSfr0CHfIQfFk8g=="
+        "requested": "[4.3.1, 4.3.1]",
+        "resolved": "4.3.1",
+        "contentHash": "qAtKMcHOAq9/zKkl0dwvF0T0pmgCQxX1rC49rJXoU8jq+lw6MC3uXy7nLFmjEI20T3Aq069eWz4LcYR64vEmJw=="
       },
       "System.Runtime.InteropServices": {
         "type": "Direct",
@@ -766,9 +766,9 @@
       },
       "System.Security.Cryptography.Algorithms": {
         "type": "Direct",
-        "requested": "[4.3.0, 4.3.0]",
-        "resolved": "4.3.0",
-        "contentHash": "W1kd2Y8mYSCgc3ULTAZ0hOP2dSdG5YauTb1089T0/kRcN2MpSAW1izOFROrJgxSlMn3ArsgHXagigyi+ibhevg=="
+        "requested": "[4.3.1, 4.3.1]",
+        "resolved": "4.3.1",
+        "contentHash": "DVUblnRfnarrI5olEC2B/OCsJQd0anjVaObQMndHSc43efbc88/RMOlDyg/EyY0ix5ecyZMXS8zMksb5ukebZA=="
       },
       "System.Security.Cryptography.Encoding": {
         "type": "Direct",
@@ -784,9 +784,9 @@
       },
       "System.Security.Cryptography.X509Certificates": {
         "type": "Direct",
-        "requested": "[4.3.0, 4.3.0]",
-        "resolved": "4.3.0",
-        "contentHash": "t2Tmu6Y2NtJ2um0RtcuhP7ZdNNxXEgUm2JeoA/0NvlMjAhKCnM1NX07TDl3244mVp3QU6LPEhT3HTtH1uF7IYw=="
+        "requested": "[4.3.2, 4.3.2]",
+        "resolved": "4.3.2",
+        "contentHash": "uwlfOnvJd7rXRvP3aV126Q9XebIIEGEaZ245Rd5/ZwOg7U7AU+AmpE0vRh2F0DFjfOTuk7MAexv4nYiNP/RYnQ=="
       },
       "System.Security.Cryptography.Xml": {
         "type": "Direct",
@@ -814,9 +814,9 @@
       },
       "System.Text.Encoding.CodePages": {
         "type": "Direct",
-        "requested": "[4.3.0, 4.3.0]",
-        "resolved": "4.3.0",
-        "contentHash": "IRiEFUa5b/Gs5Egg8oqBVoywhtOeaO2KOx3j0RfcYY/raxqBuEK7NXRDgOwtYM8qbi+7S4RPXUbNt+ZxyY0/NQ=="
+        "requested": "[4.5.1, 4.5.1]",
+        "resolved": "4.5.1",
+        "contentHash": "4J2JQXbftjPMppIHJ7IC+VXQ9XfEagN92vZZNoG12i+zReYlim5dMoXFC1Zzg7tsnKDM7JPo5bYfFK4Jheq44w=="
       },
       "System.Text.Encoding.Extensions": {
         "type": "Direct",
@@ -868,9 +868,9 @@
       },
       "System.Xml.ReaderWriter": {
         "type": "Direct",
-        "requested": "[4.3.0, 4.3.0]",
-        "resolved": "4.3.0",
-        "contentHash": "GrprA+Z0RUXaR4N7/eW71j1rgMnEnEVlgii49GZyAjTH7uliMnrOU3HNFBr6fEDBCJCIdlVNq9hHbaDR621XBA=="
+        "requested": "[4.3.1, 4.3.1]",
+        "resolved": "4.3.1",
+        "contentHash": "fVU1Xp9TEOHv1neQDtcJ4hNfYJ1pjfXzKY3VFeiRZK6HTV4Af2Ihyvq1FkPLrL1hzZhXv7NTmowQnL5DgTzIKA=="
       },
       "System.Xml.XDocument": {
         "type": "Direct",

--- a/examples/Web/packages.lock.json
+++ b/examples/Web/packages.lock.json
@@ -76,15 +76,15 @@
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "rsxgcq+BU7VDGOZ0DdyPQOSE+jw5Bb4nk6PQpG70U/ZhgKFaAnnLeEnCfHgnCBUy3kn2ZtH3ZKJL+sh9MYzR4w=="
+        "requested": "[2.1.2, 2.1.2]",
+        "resolved": "2.1.2",
+        "contentHash": "EiMovaF/QszHjp9SBJH2gUPecAmBDUZCm7sNsCSAf32dhfJMrsbXtiFz91LPXkQOz483u9P5fz8q24INJP/WTQ=="
       },
       "Microsoft.AspNetCore.Authorization.Policy": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "6Gy9rFN1/4pKgjcbb2yaOmwpjV282dGnl7ewcCvcLxQmywpolkwxe5PPI6K/VPC2sovL5BtzhxnRl3OkwJZxwg=="
+        "requested": "[2.1.2, 2.1.2]",
+        "resolved": "2.1.2",
+        "contentHash": "sf3Ai2X0/os2MVptDvWNmBfDt6YZN5N2AQ8z6vk+JU97oW+Nr6HH5h7aWaiacpj2cWPTgBQdUocGvA4ckYdCqQ=="
       },
       "Microsoft.AspNetCore.Cors": {
         "type": "Direct",
@@ -142,9 +142,9 @@
       },
       "Microsoft.AspNetCore.Http": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "pPDcCW8spnyibK3krpxrOpaFHf5fjV6k1Hsl6gfh77N/8gRYlLU7MOQDUnjpEwdlHmtxwJKQJNxZqVQOmJGRUw=="
+        "requested": "[2.1.34, 2.1.34]",
+        "resolved": "2.1.34",
+        "contentHash": "d1U34fyniRrDW0SD7KryDhXq1KWEjeE1XuLgk/qcdFHUjkjY6XztmhEmQJicGlPYKEZOe+3UMWz5EZChLwnrvQ=="
       },
       "Microsoft.AspNetCore.Http.Abstractions": {
         "type": "Direct",
@@ -154,9 +154,9 @@
       },
       "Microsoft.AspNetCore.Http.Extensions": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "ncAgV+cqsWSqjLXFUTyObGh4Tr7ShYYs3uW8Q/YpRwZn7eLV7dux5Z6GLY+rsdzmIHiia3Q2NWbLULQi7aziHw=="
+        "requested": "[2.1.21, 2.1.21]",
+        "resolved": "2.1.21",
+        "contentHash": "+T9PPrE/ZHB+jEe1a79hoWu6p87XiU/BJ3uoasjH/rPR88zk8dWO9KwE8A2zZi81UEDusAk2H8q7s/K2teRo9A=="
       },
       "Microsoft.AspNetCore.Http.Features": {
         "type": "Direct",
@@ -184,9 +184,9 @@
       },
       "Microsoft.AspNetCore.Mvc.Abstractions": {
         "type": "Direct",
-        "requested": "[2.1.3, 2.1.3]",
-        "resolved": "2.1.3",
-        "contentHash": "G0oQiJ9okq+QbH9HBbmxu8/+Vhv063Dt06RzJPzsw7/uFT7Tvq5XHU5LI3b9qudyotJIRfYBbJRNeZyXEc+ALw=="
+        "requested": "[2.1.38, 2.1.38]",
+        "resolved": "2.1.38",
+        "contentHash": "J+XhGzKPmW4D6c2OvIbz2cC1eWOJZd6/V4/2V5JUkm0uXLjFgbmM3tuYfVvncjB4vzoRAHkSTrjNTXe39eArqQ=="
       },
       "Microsoft.AspNetCore.Mvc.ApiExplorer": {
         "type": "Direct",
@@ -196,9 +196,9 @@
       },
       "Microsoft.AspNetCore.Mvc.Core": {
         "type": "Direct",
-        "requested": "[2.1.3, 2.1.3]",
-        "resolved": "2.1.3",
-        "contentHash": "qu2EOWIqz/KFw2WV0IDltHLoKjfWr60mWl9waPJwuwpjwycaDimu8fjOEigY941tMZoWjv/ZUi2kQGKHov10/g=="
+        "requested": "[2.1.38, 2.1.38]",
+        "resolved": "2.1.38",
+        "contentHash": "doPQ9IKoa4el6wdD+IeYPXNpdqyP+YwgrO1+7VFFXDzDGeQZQKcDd/ptgt1adlPdjPPr9l19d4+oCRNNURTZRQ=="
       },
       "Microsoft.AspNetCore.Mvc.Cors": {
         "type": "Direct",
@@ -214,9 +214,9 @@
       },
       "Microsoft.AspNetCore.Mvc.Formatters.Json": {
         "type": "Direct",
-        "requested": "[2.1.3, 2.1.3]",
-        "resolved": "2.1.3",
-        "contentHash": "a3tyBmMy1onYZbDHrbJ7nuE4xEQUSdD76T2KlE68s7xtANhIdbC/mW1FGTEZKzXawBygOaVVS7A1OzIiduxjUw=="
+        "requested": "[2.1.18, 2.1.18]",
+        "resolved": "2.1.18",
+        "contentHash": "p/nztOkR9q6vHb/+LGslL7I46YX6FmiF8WthATpVu+sglk3k6/uXCpv3RV9BDg8SSRkWoAMgOsolKRqwpMC4xQ=="
       },
       "Microsoft.AspNetCore.Mvc.Localization": {
         "type": "Direct",
@@ -232,15 +232,15 @@
       },
       "Microsoft.AspNetCore.Mvc.Razor.Extensions": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "dX6QcZLUbIQj2BC+lkmlAvHPrDzrknmO1YW1AUNh2GKk9iEAhlVraxzsQo10IvYdXOhJGhiqa6gVyq9fledK1g=="
+        "requested": "[2.1.2, 2.1.2]",
+        "resolved": "2.1.2",
+        "contentHash": "2IBPT1QfTgJ8whML78zmqL7tDC5wzA732gQ/z55GXQZjOWQ6VI/n9fxF+hrzTayFSHBUuGRwKj5/gg0N/NcLww=="
       },
       "Microsoft.AspNetCore.Mvc.RazorPages": {
         "type": "Direct",
-        "requested": "[2.1.3, 2.1.3]",
-        "resolved": "2.1.3",
-        "contentHash": "9XAjyPY2n1V9jRDm0XqvsgURtOI99N+Wvhu1C719lOM0dmst6tMYmed2MJCdZ7EzzLxGoK112It33/zZheXWig=="
+        "requested": "[2.1.11, 2.1.11]",
+        "resolved": "2.1.11",
+        "contentHash": "k7yIeIrd0a5nmiZusFRrq/0IhAjQlvK+YONSD4VXdbLstIUH5pVFqxSBc13HFV9GqHU7O/NyLunclVaaLAeCOg=="
       },
       "Microsoft.AspNetCore.Mvc.TagHelpers": {
         "type": "Direct",
@@ -256,27 +256,27 @@
       },
       "Microsoft.AspNetCore.Razor": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "2yYunEgYC7hOyasvMiiH+a8250l+l1R79jB6VarZ6I8fiXDNCrJ/mEEn9TS0vDidAzesOshFigepa6+qI5Cb0w=="
+        "requested": "[2.1.2, 2.1.2]",
+        "resolved": "2.1.2",
+        "contentHash": "0P/1wSjvZPURzUcvdMjc+gHTIZmFwpkspVJVD7OKTLTcAj8TlTYcP1Py/Av4UU/SkUyhtlMrY/Mo4RCjUn3kZg=="
       },
       "Microsoft.AspNetCore.Razor.Design": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "1XHObHLx6A0/57ZmLG9gfKMO/Z/gQjRXPFWQDMlPZGYwcfgufvSdmI2+RYvR5DGkbba9HIHC35ClNQ2yVNIohw=="
+        "requested": "[2.1.2, 2.1.2]",
+        "resolved": "2.1.2",
+        "contentHash": "fe1+dpy+eM4IX1zodsvkihO1Spuj0NecfStWzvkYoMo7/ziOsqSv4vFK36ZpBfHa4gpdCEwaU46EPzdq+ZDYhQ=="
       },
       "Microsoft.AspNetCore.Razor.Language": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "NbDH62ez/AZzSAGZuy6dIMBDMV0HmBlbWJqPw/ZX+Ooz8x1oZq6i/LbPbt34CQlAkrm7lnAlWZq+cE7dzkvGiQ=="
+        "requested": "[2.1.2, 2.1.2]",
+        "resolved": "2.1.2",
+        "contentHash": "sTajqea7Ef0bIB5z+/ByhmznbsqhA+Q4lQw6zSAZC873o6b5yQTu9/5ejKO2B8Kl2S3mdYOJIGY6Eq/IRd788w=="
       },
       "Microsoft.AspNetCore.Razor.Runtime": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "m+lFv8BGZiR/1mtuBCwCtwvoQlx0QpjUbH6ixqqm7v8+uhXo6RKGV4CHBDozuJhhI4qb9dxNyyWhVm3S0bY8Zw=="
+        "requested": "[2.1.2, 2.1.2]",
+        "resolved": "2.1.2",
+        "contentHash": "3TpndT7RJsBR7cf14eocdkMUo6NMXOnhyFbWeJWHjL+MSQnRAE17V9BmI9fhQblsPBpLRb3XNN+WXfatVujMsA=="
       },
       "Microsoft.AspNetCore.ResponseCaching.Abstractions": {
         "type": "Direct",
@@ -322,9 +322,9 @@
       },
       "Microsoft.CodeAnalysis.Razor": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "hc29VUVlF2t2TfOR3c5X2mun3h5KkswkarpWBffEG4iHoSdoEueo82dplwoXg9lH2vw0mK7VYPyawcKy6YHv3A=="
+        "requested": "[2.1.2, 2.1.2]",
+        "resolved": "2.1.2",
+        "contentHash": "Lx/LGkG0Il/sFFHptpAO4Ry4MXyl6XwwHUyGAcJlaXymFThkfx+p2PuvZtFE9ftf5w9RFWOETJzhGOT06PJnlQ=="
       },
       "Microsoft.CodeDom.Providers.DotNetCompilerPlatform": {
         "type": "Direct",
@@ -352,15 +352,15 @@
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "LbT7Ry1waNBksnngFNdaNmEglQMJ8g7F6tbSoyoqpEW35W/Cj4YwURDVwoRS+jtyf6YKsTdPHV643jMMuJBi9g=="
+        "requested": "[2.1.23, 2.1.23]",
+        "resolved": "2.1.23",
+        "contentHash": "yG4eeRGzCuCSuKd+SxnT9Km9yaP+JgV4g0SSBY6sUD7mOWyC7PHGHWfhZgF5TjDcavb96hGxD+wrXVnh/MTktA=="
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "jR14GhHGmPzq7QChnYa3Uiu+s/QerwxbMPAlA0Ei0shDJlrRoD6FSb9hP8rmSX6oai9Z64SWbXlwBhi3L/vj9g=="
+        "requested": "[2.1.23, 2.1.23]",
+        "resolved": "2.1.23",
+        "contentHash": "00E3Y0sUISXmSL+BHaesNae1x06g8Bp3b6e9G3rlEn4FePu4TZ14su0PeeD8dgN9WUxbwRWMR6hf6r7QiTVQLQ=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Direct",
@@ -376,9 +376,9 @@
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "fcLCTS03poWE4v9tSNBr3pWn0QwGgAn1vzqHXlXgvqZeOc7LvQNzaWcKRQZTdEc3+YhQKwMsOtm3VKSA2aWQ8w=="
+        "requested": "[2.1.10, 2.1.10]",
+        "resolved": "2.1.10",
+        "contentHash": "anSrDPFjcz6oBQjrul2vSHCg/wOZ2gJc1ZNzm03LtkA9S17x8xnkLaT599uuFnl6JSZJgQy4hoHVzt2+bIDc9w=="
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
         "type": "Direct",
@@ -490,9 +490,9 @@
       },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "SErON45qh4ogDp6lr6UvVmFYW0FERihW+IQ+2JyFv1PUyWktcJytFaWH5zarufJvZwhci7Rf1IyGXr9pVEadTw=="
+        "requested": "[2.1.6, 2.1.6]",
+        "resolved": "2.1.6",
+        "contentHash": "4Xva9hlVx/2zv5bUr9QlPSCQBh5MwVkMoJ8jd9lgHNgx2C2Ol35/0KZrNsmKffcaKjb+Bj6btBq1QjPozhqTPQ=="
       },
       "Microsoft.Extensions.Options": {
         "type": "Direct",
@@ -508,9 +508,9 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "scJ1GZNIxMmjpENh0UZ8XCQ6vzr/LzeF9WvEA51Ix2OQGAs9WPgPu8ABVUdvpKPLuor/t05gm6menJK3PwqOXg=="
+        "requested": "[2.1.6, 2.1.6]",
+        "resolved": "2.1.6",
+        "contentHash": "uf0zvl2v/OoDUkz9JnPi1z4B2YbjkgN+pyOKoWD/qwB3ytYoAHFg03rTZ9K8pLdjp/YQlH5B2gY0Li8vrLYNQw=="
       },
       "Microsoft.Extensions.WebEncoders": {
         "type": "Direct",
@@ -520,9 +520,9 @@
       },
       "Microsoft.Net.Http.Headers": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.1.1]",
-        "resolved": "2.1.1",
-        "contentHash": "lPNIphl8b2EuhOE9dMH6EZDmu7pS882O+HMi5BJNsigxHaWlBrYxZHFZgE18cyaPp6SSZcTkKkuzfjV/RRQKlA=="
+        "requested": "[2.1.14, 2.1.14]",
+        "resolved": "2.1.14",
+        "contentHash": "+45BYzxrBr0Pqc9B/9EhX/KvlGqe0PrB+WgJW8ZrGmoyIMMs8aObPfgZbALpjN0VOq1/WYy1y5RcEOw53MRuMg=="
       },
       "Microsoft.Owin": {
         "type": "Direct",
@@ -580,9 +580,9 @@
       },
       "System.Buffers": {
         "type": "Direct",
-        "requested": "[4.5.0, 4.5.0]",
-        "resolved": "4.5.0",
-        "contentHash": "pL2ChpaRRWI/p4LXyy4RgeWlYF2sgfj/pnVMvBqwNFr5cXg7CXNnWZWxrOONLg8VGdFB8oB+EG2Qw4MLgTOe+A=="
+        "requested": "[4.5.1, 4.5.1]",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
       },
       "System.Collections": {
         "type": "Direct",
@@ -694,15 +694,15 @@
       },
       "System.Memory": {
         "type": "Direct",
-        "requested": "[4.5.1, 4.5.1]",
-        "resolved": "4.5.1",
-        "contentHash": "sDJYJpGtTgx+23Ayu5euxG5mAXWdkDb4+b0rD0Cab0M1oQS9H0HXGPriKcqpXuiJDTV7fTp/d+fMDJmnr6sNvA=="
+        "requested": "[4.5.5, 4.5.5]",
+        "resolved": "4.5.5",
+        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw=="
       },
       "System.Numerics.Vectors": {
         "type": "Direct",
-        "requested": "[4.4.0, 4.4.0]",
-        "resolved": "4.4.0",
-        "contentHash": "UiLzLW+Lw6HLed1Hcg+8jSRttrbuXv7DANVj0DkL9g6EnnzbL75EB7EWsw5uRbhxd/4YdG8li5XizGWepmG3PQ=="
+        "requested": "[4.5.0, 4.5.0]",
+        "resolved": "4.5.0",
+        "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
       },
       "System.Reflection": {
         "type": "Direct",
@@ -730,9 +730,9 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Direct",
-        "requested": "[4.5.1, 4.5.1]",
-        "resolved": "4.5.1",
-        "contentHash": "Zh8t8oqolRaFa9vmOZfdQm/qKejdqz0J9kr7o2Fu0vPeoH3BL1EOXipKWwkWtLT1JPzjByrF19fGuFlNbmPpiw=="
+        "requested": "[4.5.3, 4.5.3]",
+        "resolved": "4.5.3",
+        "contentHash": "3TIsJhD1EiiT0w2CcDMN/iSSwnNnsrnbzeVHSKkaEgV85txMprmuO+Yq2AdSbeVGcg28pdNDTPK87tJhX7VFHw=="
       },
       "System.Runtime.Extensions": {
         "type": "Direct",
@@ -802,9 +802,9 @@
       },
       "System.Security.Principal.Windows": {
         "type": "Direct",
-        "requested": "[4.5.0, 4.5.0]",
-        "resolved": "4.5.0",
-        "contentHash": "U77HfRXlZlOeIXd//Yoj6Jnk8AXlbeisf1oq1os+hxOGVnuG+lGSfGqTwTZBoORFF6j/0q7HXIl8cqwQ9aUGqQ=="
+        "requested": "[4.5.1, 4.5.1]",
+        "resolved": "4.5.1",
+        "contentHash": "L3R/xk1s+AJB/ZRrwXyjXMmKp+RNgLP92LSidWEM0iCouznJoiiBloDCxRTjmo8hTDAKSWaMrltsttUzg1RhjA=="
       },
       "System.Text.Encoding": {
         "type": "Direct",
@@ -826,9 +826,9 @@
       },
       "System.Text.Encodings.Web": {
         "type": "Direct",
-        "requested": "[4.5.0, 4.5.0]",
-        "resolved": "4.5.0",
-        "contentHash": "Xg4G4Indi4dqP1iuAiMSwpiWS54ZghzR644OtsRCm/m/lBMG8dUBhLVN7hLm8NNrNTR+iGbshCPTwrvxZPlm4g=="
+        "requested": "[4.5.1, 4.5.1]",
+        "resolved": "4.5.1",
+        "contentHash": "8lfETN/1lu0QD+XQaDCxn6InX3KYJHCFO6Iqrm92zn9eOEeonTuyisKxW0nLZfse598LibhEItiRdPzVn8Beyg=="
       },
       "System.Threading": {
         "type": "Direct",
@@ -844,9 +844,9 @@
       },
       "System.Threading.Tasks.Extensions": {
         "type": "Direct",
-        "requested": "[4.5.1, 4.5.1]",
-        "resolved": "4.5.1",
-        "contentHash": "WSKUTtLhPR8gllzIWO2x6l4lmAIfbyMAiTlyXAis4QBDonXK4b4S6F8zGARX4/P8wH3DH+sLdhamCiHn+fTU1A=="
+        "requested": "[4.5.4, 4.5.4]",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
       },
       "System.Threading.Tasks.Parallel": {
         "type": "Direct",
@@ -862,9 +862,9 @@
       },
       "System.ValueTuple": {
         "type": "Direct",
-        "requested": "[4.3.0, 4.3.0]",
-        "resolved": "4.3.0",
-        "contentHash": "cNLEvBX3d6MMQRZe3SMFNukVbitDAEpVZO17qa0/2FHxZ7Y7PpFRpr6m2615XYM/tYYYf0B+WyHNujqIw8Luwg=="
+        "requested": "[4.5.0, 4.5.0]",
+        "resolved": "4.5.0",
+        "contentHash": "okurQJO6NRE/apDIP23ajJ0hpiNmJ+f0BwOlB/cSqTLQlw5upkf+5+96+iG2Jw40G1fCVCyPz/FhIABUjMR+RQ=="
       },
       "System.Xml.ReaderWriter": {
         "type": "Direct",

--- a/src/AspNet.Identity.EntityFramework/packages.lock.json
+++ b/src/AspNet.Identity.EntityFramework/packages.lock.json
@@ -418,23 +418,23 @@
       "unravel.aspnet.identity": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.AspNet.Identity.Core": "2.2.3",
-          "Microsoft.AspNet.Identity.Owin": "2.2.3",
-          "Unravel.Startup": "1.0.0"
+          "Microsoft.AspNet.Identity.Core": "[2.2.3, )",
+          "Microsoft.AspNet.Identity.Owin": "[2.2.3, )",
+          "Unravel.Startup": "[1.0.0, )"
         }
       },
       "unravel.startup": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting": "2.1.1",
-          "Microsoft.AspNetCore.Owin": "2.1.1",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.1.1",
-          "Microsoft.Extensions.Configuration.Json": "2.1.1",
-          "Microsoft.Extensions.Configuration.UserSecrets": "2.1.1",
-          "Microsoft.Extensions.DependencyInjection": "2.1.1",
-          "Microsoft.Extensions.Logging.Configuration": "2.1.1",
-          "Microsoft.Extensions.Logging.Debug": "2.1.1",
-          "Microsoft.Owin.Host.SystemWeb": "4.2.2"
+          "Microsoft.AspNetCore.Hosting": "[2.1.1, 2.2.0)",
+          "Microsoft.AspNetCore.Owin": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.Json": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.DependencyInjection": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Logging.Debug": "[2.1.1, 2.2.0)",
+          "Microsoft.Owin.Host.SystemWeb": "[4.2.2, )"
         }
       }
     }

--- a/src/AspNet.Identity/packages.lock.json
+++ b/src/AspNet.Identity/packages.lock.json
@@ -405,15 +405,15 @@
       "unravel.startup": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting": "2.1.1",
-          "Microsoft.AspNetCore.Owin": "2.1.1",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.1.1",
-          "Microsoft.Extensions.Configuration.Json": "2.1.1",
-          "Microsoft.Extensions.Configuration.UserSecrets": "2.1.1",
-          "Microsoft.Extensions.DependencyInjection": "2.1.1",
-          "Microsoft.Extensions.Logging.Configuration": "2.1.1",
-          "Microsoft.Extensions.Logging.Debug": "2.1.1",
-          "Microsoft.Owin.Host.SystemWeb": "4.2.2"
+          "Microsoft.AspNetCore.Hosting": "[2.1.1, 2.2.0)",
+          "Microsoft.AspNetCore.Owin": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.Json": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.DependencyInjection": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Logging.Debug": "[2.1.1, 2.2.0)",
+          "Microsoft.Owin.Host.SystemWeb": "[4.2.2, )"
         }
       }
     }

--- a/src/AspNet.Mvc/packages.lock.json
+++ b/src/AspNet.Mvc/packages.lock.json
@@ -386,14 +386,14 @@
       "unravel.startup": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting": "[2.1.1, )",
-          "Microsoft.AspNetCore.Owin": "[2.1.1, )",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, )",
-          "Microsoft.Extensions.Configuration.Json": "[2.1.1, )",
-          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, )",
-          "Microsoft.Extensions.DependencyInjection": "[2.1.1, )",
-          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, )",
-          "Microsoft.Extensions.Logging.Debug": "[2.1.1, )",
+          "Microsoft.AspNetCore.Hosting": "[2.1.1, 2.2.0)",
+          "Microsoft.AspNetCore.Owin": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.Json": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.DependencyInjection": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Logging.Debug": "[2.1.1, 2.2.0)",
           "Microsoft.Owin.Host.SystemWeb": "[4.2.2, )"
         }
       }

--- a/src/AspNet.WebApi/packages.lock.json
+++ b/src/AspNet.WebApi/packages.lock.json
@@ -390,14 +390,14 @@
       "unravel.startup": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting": "[2.1.1, )",
-          "Microsoft.AspNetCore.Owin": "[2.1.1, )",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, )",
-          "Microsoft.Extensions.Configuration.Json": "[2.1.1, )",
-          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, )",
-          "Microsoft.Extensions.DependencyInjection": "[2.1.1, )",
-          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, )",
-          "Microsoft.Extensions.Logging.Debug": "[2.1.1, )",
+          "Microsoft.AspNetCore.Hosting": "[2.1.1, 2.2.0)",
+          "Microsoft.AspNetCore.Owin": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.Json": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.DependencyInjection": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Logging.Debug": "[2.1.1, 2.2.0)",
           "Microsoft.Owin.Host.SystemWeb": "[4.2.2, )"
         }
       }

--- a/src/AspNetCore.Mvc.ViewFeatures/Unravel.AspNetCore.Mvc.ViewFeatures.csproj
+++ b/src/AspNetCore.Mvc.ViewFeatures/Unravel.AspNetCore.Mvc.ViewFeatures.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="[2.1.3,2.2.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNetCore.Mvc.ViewFeatures/packages.lock.json
+++ b/src/AspNetCore.Mvc.ViewFeatures/packages.lock.json
@@ -229,8 +229,8 @@
       },
       "Microsoft.AspNetCore.Mvc.Core": {
         "type": "Transitive",
-        "resolved": "2.1.3",
-        "contentHash": "qu2EOWIqz/KFw2WV0IDltHLoKjfWr60mWl9waPJwuwpjwycaDimu8fjOEigY941tMZoWjv/ZUi2kQGKHov10/g==",
+        "resolved": "2.1.38",
+        "contentHash": "doPQ9IKoa4el6wdD+IeYPXNpdqyP+YwgrO1+7VFFXDzDGeQZQKcDd/ptgt1adlPdjPPr9l19d4+oCRNNURTZRQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Authentication.Core": "2.1.1",
           "Microsoft.AspNetCore.Authorization.Policy": "2.1.1",
@@ -245,7 +245,7 @@
           "Microsoft.Extensions.FileProviders.Abstractions": "2.1.1",
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1",
           "System.Diagnostics.DiagnosticSource": "4.5.1",
-          "System.Threading.Tasks.Extensions": "4.5.1"
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.AspNetCore.Mvc.DataAnnotations": {
@@ -635,8 +635,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.5.1",
-        "contentHash": "Zh8t8oqolRaFa9vmOZfdQm/qKejdqz0J9kr7o2Fu0vPeoH3BL1EOXipKWwkWtLT1JPzjByrF19fGuFlNbmPpiw=="
+        "resolved": "4.5.3",
+        "contentHash": "3TIsJhD1EiiT0w2CcDMN/iSSwnNnsrnbzeVHSKkaEgV85txMprmuO+Yq2AdSbeVGcg28pdNDTPK87tJhX7VFHw=="
       },
       "System.Runtime.InteropServices.RuntimeInformation": {
         "type": "Transitive",
@@ -679,10 +679,10 @@
       },
       "System.Threading.Tasks.Extensions": {
         "type": "Transitive",
-        "resolved": "4.5.1",
-        "contentHash": "WSKUTtLhPR8gllzIWO2x6l4lmAIfbyMAiTlyXAis4QBDonXK4b4S6F8zGARX4/P8wH3DH+sLdhamCiHn+fTU1A==",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
         "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "4.5.0"
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
         }
       },
       "unravel.aspnet.mvc": {
@@ -695,7 +695,7 @@
       "unravel.aspnetcore.mvc": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.AspNetCore.Mvc.Core": "[2.1.3, 2.2.0)",
+          "Microsoft.AspNetCore.Mvc.Core": "[2.1.38, 2.2.0)",
           "Unravel.Startup": "[1.0.0, )"
         }
       },

--- a/src/AspNetCore.Mvc.ViewFeatures/packages.lock.json
+++ b/src/AspNetCore.Mvc.ViewFeatures/packages.lock.json
@@ -4,7 +4,7 @@
     ".NETFramework,Version=v4.7.2": {
       "Microsoft.AspNetCore.Mvc.ViewFeatures": {
         "type": "Direct",
-        "requested": "[2.1.3, )",
+        "requested": "[2.1.3, 2.2.0)",
         "resolved": "2.1.3",
         "contentHash": "UwFP+BjvqzF5V9NVga0kLb4oS5LceNkYPFtMvd9imezn0+/vHKSxiIp0cWvHuksNGMld/9JjSH2KQMt0i3zkzA==",
         "dependencies": {
@@ -695,21 +695,21 @@
       "unravel.aspnetcore.mvc": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.AspNetCore.Mvc.Core": "[2.1.3, )",
+          "Microsoft.AspNetCore.Mvc.Core": "[2.1.3, 2.2.0)",
           "Unravel.Startup": "[1.0.0, )"
         }
       },
       "unravel.startup": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting": "[2.1.1, )",
-          "Microsoft.AspNetCore.Owin": "[2.1.1, )",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, )",
-          "Microsoft.Extensions.Configuration.Json": "[2.1.1, )",
-          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, )",
-          "Microsoft.Extensions.DependencyInjection": "[2.1.1, )",
-          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, )",
-          "Microsoft.Extensions.Logging.Debug": "[2.1.1, )",
+          "Microsoft.AspNetCore.Hosting": "[2.1.1, 2.2.0)",
+          "Microsoft.AspNetCore.Owin": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.Json": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.DependencyInjection": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Logging.Debug": "[2.1.1, 2.2.0)",
           "Microsoft.Owin.Host.SystemWeb": "[4.2.2, )"
         }
       }

--- a/src/AspNetCore.Mvc/Unravel.AspNetCore.Mvc.csproj
+++ b/src/AspNetCore.Mvc/Unravel.AspNetCore.Mvc.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.1.3,2.2.0)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.1.38,2.2.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNetCore.Mvc/Unravel.AspNetCore.Mvc.csproj
+++ b/src/AspNetCore.Mvc/Unravel.AspNetCore.Mvc.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.1.3,2.2.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNetCore.Mvc/packages.lock.json
+++ b/src/AspNetCore.Mvc/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETFramework,Version=v4.7.2": {
       "Microsoft.AspNetCore.Mvc.Core": {
         "type": "Direct",
-        "requested": "[2.1.3, 2.2.0)",
-        "resolved": "2.1.3",
-        "contentHash": "qu2EOWIqz/KFw2WV0IDltHLoKjfWr60mWl9waPJwuwpjwycaDimu8fjOEigY941tMZoWjv/ZUi2kQGKHov10/g==",
+        "requested": "[2.1.38, 2.2.0)",
+        "resolved": "2.1.38",
+        "contentHash": "doPQ9IKoa4el6wdD+IeYPXNpdqyP+YwgrO1+7VFFXDzDGeQZQKcDd/ptgt1adlPdjPPr9l19d4+oCRNNURTZRQ==",
         "dependencies": {
           "Microsoft.AspNetCore.Authentication.Core": "2.1.1",
           "Microsoft.AspNetCore.Authorization.Policy": "2.1.1",
@@ -21,7 +21,7 @@
           "Microsoft.Extensions.FileProviders.Abstractions": "2.1.1",
           "Microsoft.Extensions.Logging.Abstractions": "2.1.1",
           "System.Diagnostics.DiagnosticSource": "4.5.1",
-          "System.Threading.Tasks.Extensions": "4.5.1"
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.AspNetCore.Authentication.Abstractions": {
@@ -460,8 +460,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.5.1",
-        "contentHash": "Zh8t8oqolRaFa9vmOZfdQm/qKejdqz0J9kr7o2Fu0vPeoH3BL1EOXipKWwkWtLT1JPzjByrF19fGuFlNbmPpiw=="
+        "resolved": "4.5.3",
+        "contentHash": "3TIsJhD1EiiT0w2CcDMN/iSSwnNnsrnbzeVHSKkaEgV85txMprmuO+Yq2AdSbeVGcg28pdNDTPK87tJhX7VFHw=="
       },
       "System.Runtime.InteropServices.RuntimeInformation": {
         "type": "Transitive",
@@ -475,10 +475,10 @@
       },
       "System.Threading.Tasks.Extensions": {
         "type": "Transitive",
-        "resolved": "4.5.1",
-        "contentHash": "WSKUTtLhPR8gllzIWO2x6l4lmAIfbyMAiTlyXAis4QBDonXK4b4S6F8zGARX4/P8wH3DH+sLdhamCiHn+fTU1A==",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
         "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "4.5.0"
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
         }
       },
       "unravel.startup": {

--- a/src/AspNetCore.Mvc/packages.lock.json
+++ b/src/AspNetCore.Mvc/packages.lock.json
@@ -4,7 +4,7 @@
     ".NETFramework,Version=v4.7.2": {
       "Microsoft.AspNetCore.Mvc.Core": {
         "type": "Direct",
-        "requested": "[2.1.3, )",
+        "requested": "[2.1.3, 2.2.0)",
         "resolved": "2.1.3",
         "contentHash": "qu2EOWIqz/KFw2WV0IDltHLoKjfWr60mWl9waPJwuwpjwycaDimu8fjOEigY941tMZoWjv/ZUi2kQGKHov10/g==",
         "dependencies": {
@@ -484,15 +484,15 @@
       "unravel.startup": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.AspNetCore.Hosting": "2.1.1",
-          "Microsoft.AspNetCore.Owin": "2.1.1",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.1.1",
-          "Microsoft.Extensions.Configuration.Json": "2.1.1",
-          "Microsoft.Extensions.Configuration.UserSecrets": "2.1.1",
-          "Microsoft.Extensions.DependencyInjection": "2.1.1",
-          "Microsoft.Extensions.Logging.Configuration": "2.1.1",
-          "Microsoft.Extensions.Logging.Debug": "2.1.1",
-          "Microsoft.Owin.Host.SystemWeb": "4.2.2"
+          "Microsoft.AspNetCore.Hosting": "[2.1.1, 2.2.0)",
+          "Microsoft.AspNetCore.Owin": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.Json": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.DependencyInjection": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Logging.Debug": "[2.1.1, 2.2.0)",
+          "Microsoft.Owin.Host.SystemWeb": "[4.2.2, )"
         }
       }
     }

--- a/src/Startup/Unravel.Startup.csproj
+++ b/src/Startup/Unravel.Startup.csproj
@@ -13,14 +13,14 @@
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Owin" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.1.1,2.2.0)" />
+    <PackageReference Include="Microsoft.AspNetCore.Owin" Version="[2.1.1,2.2.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[2.1.1,2.2.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[2.1.1,2.2.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="[2.1.1,2.2.0)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[2.1.1,2.2.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="[2.1.1,2.2.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="[2.1.1,2.2.0)" />
     <PackageReference Include="Microsoft.Owin.Host.SystemWeb" Version="4.2.2" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Startup/packages.lock.json
+++ b/src/Startup/packages.lock.json
@@ -4,7 +4,7 @@
     ".NETFramework,Version=v4.7.2": {
       "Microsoft.AspNetCore.Hosting": {
         "type": "Direct",
-        "requested": "[2.1.1, )",
+        "requested": "[2.1.1, 2.2.0)",
         "resolved": "2.1.1",
         "contentHash": "MqYc0DUxrhAPnb5b4HFspxsoJT+gJlLsliSxIgovf4BsbmpaXQId0/pDiVzLuEbmks2w1/lRfY8w0lQOuK1jQQ==",
         "dependencies": {
@@ -25,7 +25,7 @@
       },
       "Microsoft.AspNetCore.Owin": {
         "type": "Direct",
-        "requested": "[2.1.1, )",
+        "requested": "[2.1.1, 2.2.0)",
         "resolved": "2.1.1",
         "contentHash": "OKovgdeKNc2XE31363rCa5ON30FFlcjC4zfsXRokpHZdVUX1A0cllNlXyNggJf1K+5DepBr/fv6BuuX6x/ZZYQ==",
         "dependencies": {
@@ -34,7 +34,7 @@
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
         "type": "Direct",
-        "requested": "[2.1.1, )",
+        "requested": "[2.1.1, 2.2.0)",
         "resolved": "2.1.1",
         "contentHash": "6xMxFIfKL+7J/jwlk8zV8I61sF3+DRG19iKQxnSfYQU+iMMjGbcWNCHFF/3MHf3o4sTZPZ8D6Io+GwKFc3TIZA==",
         "dependencies": {
@@ -43,7 +43,7 @@
       },
       "Microsoft.Extensions.Configuration.Json": {
         "type": "Direct",
-        "requested": "[2.1.1, )",
+        "requested": "[2.1.1, 2.2.0)",
         "resolved": "2.1.1",
         "contentHash": "IFpONpvdhVEE3S3F4fTYkpT/GyIHtumy2m0HniQanJ80Pj/pUF3Z4wjrHEp1G78rPD+WTo5fRlhdJfuU1Tv2GQ==",
         "dependencies": {
@@ -54,7 +54,7 @@
       },
       "Microsoft.Extensions.Configuration.UserSecrets": {
         "type": "Direct",
-        "requested": "[2.1.1, )",
+        "requested": "[2.1.1, 2.2.0)",
         "resolved": "2.1.1",
         "contentHash": "/HeMnhc9a6Ou9V+QIdGYHtYuOf0t0RQ//odFUrJ249F6W78pJyVDZY7RnhH4UMF+WLOJpo6hh010DIlW2nqqSA==",
         "dependencies": {
@@ -63,7 +63,7 @@
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Direct",
-        "requested": "[2.1.1, )",
+        "requested": "[2.1.1, 2.2.0)",
         "resolved": "2.1.1",
         "contentHash": "RVdgNWT/73M0eCpreGpWv5NmbHFGQzzW+G7nChK8ej84m+d1nzeWrtqcRYnEpKNx3B8V/Uek4tNP0WCaCNjYnQ==",
         "dependencies": {
@@ -72,7 +72,7 @@
       },
       "Microsoft.Extensions.Logging.Configuration": {
         "type": "Direct",
-        "requested": "[2.1.1, )",
+        "requested": "[2.1.1, 2.2.0)",
         "resolved": "2.1.1",
         "contentHash": "Z3AzFM21fL/ux0kZAbTE+HDPQ46vuh0dqzhlBm6w7/029RxZLvV6bUUsAs70i2r4JfShhCjBYZ+bTjR42diFVA==",
         "dependencies": {
@@ -82,7 +82,7 @@
       },
       "Microsoft.Extensions.Logging.Debug": {
         "type": "Direct",
-        "requested": "[2.1.1, )",
+        "requested": "[2.1.1, 2.2.0)",
         "resolved": "2.1.1",
         "contentHash": "72k7rBz2DL3ev59gX+uwOmA/pEegGzi5SRZhysPIi7+2+JoyLlIRBPscJ8OzOI344Bq27cTByGHDoYWOrq73vg==",
         "dependencies": {

--- a/util/Start-IisExpress.ps1
+++ b/util/Start-IisExpress.ps1
@@ -21,4 +21,9 @@ Start-Process -PassThru ./iisexpress "/site:$name /trace:error" | Out-Null
 
 Pop-Location
 
-return $url
+Write-Warning "Connecting to $url"
+$res = Invoke-WebRequest $url -SkipCertificateCheck -Method HEAD -MaximumRetryCount 10 -RetryIntervalSec 3 -Verbose
+if ($res.StatusCode -eq 200) {
+  return $url
+}
+exit 1


### PR DESCRIPTION
Most NuGet updates aren't allowed due to [limits on support](https://dotnet.microsoft.com/en-us/platform/support/policy/aspnet/2.1-packages) (and [I think a few are missing](https://learn.microsoft.com/en-us/answers/questions/1327232/microsoft-aspnetcore-dataprotection-2-1-1-dependen)), so added constraints on those references.