### PR TITLE
Remove `Microsoft.Extensions.*` Constraints

### DIFF
--- a/src/AspNet.Identity.EntityFramework/packages.lock.json
+++ b/src/AspNet.Identity.EntityFramework/packages.lock.json
@@ -454,12 +454,12 @@
         "dependencies": {
           "Microsoft.AspNetCore.Hosting": "[2.1.1, 2.2.0)",
           "Microsoft.AspNetCore.Owin": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.Json": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.DependencyInjection": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Logging.Debug": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, )",
+          "Microsoft.Extensions.Configuration.Json": "[2.1.1, )",
+          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, )",
+          "Microsoft.Extensions.DependencyInjection": "[2.1.1, )",
+          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, )",
+          "Microsoft.Extensions.Logging.Debug": "[2.1.1, )",
           "Microsoft.Owin.Host.SystemWeb": "[4.2.2, )"
         }
       }

--- a/src/AspNet.Identity/packages.lock.json
+++ b/src/AspNet.Identity/packages.lock.json
@@ -433,12 +433,12 @@
         "dependencies": {
           "Microsoft.AspNetCore.Hosting": "[2.1.1, 2.2.0)",
           "Microsoft.AspNetCore.Owin": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.Json": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.DependencyInjection": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Logging.Debug": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, )",
+          "Microsoft.Extensions.Configuration.Json": "[2.1.1, )",
+          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, )",
+          "Microsoft.Extensions.DependencyInjection": "[2.1.1, )",
+          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, )",
+          "Microsoft.Extensions.Logging.Debug": "[2.1.1, )",
           "Microsoft.Owin.Host.SystemWeb": "[4.2.2, )"
         }
       }

--- a/src/AspNet.Mvc/packages.lock.json
+++ b/src/AspNet.Mvc/packages.lock.json
@@ -414,12 +414,12 @@
         "dependencies": {
           "Microsoft.AspNetCore.Hosting": "[2.1.1, 2.2.0)",
           "Microsoft.AspNetCore.Owin": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.Json": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.DependencyInjection": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Logging.Debug": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, )",
+          "Microsoft.Extensions.Configuration.Json": "[2.1.1, )",
+          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, )",
+          "Microsoft.Extensions.DependencyInjection": "[2.1.1, )",
+          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, )",
+          "Microsoft.Extensions.Logging.Debug": "[2.1.1, )",
           "Microsoft.Owin.Host.SystemWeb": "[4.2.2, )"
         }
       }

--- a/src/AspNet.WebApi/packages.lock.json
+++ b/src/AspNet.WebApi/packages.lock.json
@@ -418,12 +418,12 @@
         "dependencies": {
           "Microsoft.AspNetCore.Hosting": "[2.1.1, 2.2.0)",
           "Microsoft.AspNetCore.Owin": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.Json": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.DependencyInjection": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Logging.Debug": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, )",
+          "Microsoft.Extensions.Configuration.Json": "[2.1.1, )",
+          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, )",
+          "Microsoft.Extensions.DependencyInjection": "[2.1.1, )",
+          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, )",
+          "Microsoft.Extensions.Logging.Debug": "[2.1.1, )",
           "Microsoft.Owin.Host.SystemWeb": "[4.2.2, )"
         }
       }

--- a/src/AspNetCore.Mvc.ViewFeatures/packages.lock.json
+++ b/src/AspNetCore.Mvc.ViewFeatures/packages.lock.json
@@ -730,12 +730,12 @@
         "dependencies": {
           "Microsoft.AspNetCore.Hosting": "[2.1.1, 2.2.0)",
           "Microsoft.AspNetCore.Owin": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.Json": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.DependencyInjection": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Logging.Debug": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, )",
+          "Microsoft.Extensions.Configuration.Json": "[2.1.1, )",
+          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, )",
+          "Microsoft.Extensions.DependencyInjection": "[2.1.1, )",
+          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, )",
+          "Microsoft.Extensions.Logging.Debug": "[2.1.1, )",
           "Microsoft.Owin.Host.SystemWeb": "[4.2.2, )"
         }
       }

--- a/src/AspNetCore.Mvc/packages.lock.json
+++ b/src/AspNetCore.Mvc/packages.lock.json
@@ -512,12 +512,12 @@
         "dependencies": {
           "Microsoft.AspNetCore.Hosting": "[2.1.1, 2.2.0)",
           "Microsoft.AspNetCore.Owin": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.Json": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.DependencyInjection": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, 2.2.0)",
-          "Microsoft.Extensions.Logging.Debug": "[2.1.1, 2.2.0)",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[2.1.1, )",
+          "Microsoft.Extensions.Configuration.Json": "[2.1.1, )",
+          "Microsoft.Extensions.Configuration.UserSecrets": "[2.1.1, )",
+          "Microsoft.Extensions.DependencyInjection": "[2.1.1, )",
+          "Microsoft.Extensions.Logging.Configuration": "[2.1.1, )",
+          "Microsoft.Extensions.Logging.Debug": "[2.1.1, )",
           "Microsoft.Owin.Host.SystemWeb": "[4.2.2, )"
         }
       }

--- a/src/Startup/Unravel.Startup.csproj
+++ b/src/Startup/Unravel.Startup.csproj
@@ -15,12 +15,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.1.1,2.2.0)" />
     <PackageReference Include="Microsoft.AspNetCore.Owin" Version="[2.1.1,2.2.0)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[2.1.1,2.2.0)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[2.1.1,2.2.0)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="[2.1.1,2.2.0)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[2.1.1,2.2.0)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="[2.1.1,2.2.0)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="[2.1.1,2.2.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
     <PackageReference Include="Microsoft.Owin.Host.SystemWeb" Version="4.2.2" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Startup/packages.lock.json
+++ b/src/Startup/packages.lock.json
@@ -34,7 +34,7 @@
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.2.0)",
+        "requested": "[2.1.1, )",
         "resolved": "2.1.1",
         "contentHash": "6xMxFIfKL+7J/jwlk8zV8I61sF3+DRG19iKQxnSfYQU+iMMjGbcWNCHFF/3MHf3o4sTZPZ8D6Io+GwKFc3TIZA==",
         "dependencies": {
@@ -43,7 +43,7 @@
       },
       "Microsoft.Extensions.Configuration.Json": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.2.0)",
+        "requested": "[2.1.1, )",
         "resolved": "2.1.1",
         "contentHash": "IFpONpvdhVEE3S3F4fTYkpT/GyIHtumy2m0HniQanJ80Pj/pUF3Z4wjrHEp1G78rPD+WTo5fRlhdJfuU1Tv2GQ==",
         "dependencies": {
@@ -54,7 +54,7 @@
       },
       "Microsoft.Extensions.Configuration.UserSecrets": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.2.0)",
+        "requested": "[2.1.1, )",
         "resolved": "2.1.1",
         "contentHash": "/HeMnhc9a6Ou9V+QIdGYHtYuOf0t0RQ//odFUrJ249F6W78pJyVDZY7RnhH4UMF+WLOJpo6hh010DIlW2nqqSA==",
         "dependencies": {
@@ -63,7 +63,7 @@
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.2.0)",
+        "requested": "[2.1.1, )",
         "resolved": "2.1.1",
         "contentHash": "RVdgNWT/73M0eCpreGpWv5NmbHFGQzzW+G7nChK8ej84m+d1nzeWrtqcRYnEpKNx3B8V/Uek4tNP0WCaCNjYnQ==",
         "dependencies": {
@@ -72,7 +72,7 @@
       },
       "Microsoft.Extensions.Logging.Configuration": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.2.0)",
+        "requested": "[2.1.1, )",
         "resolved": "2.1.1",
         "contentHash": "Z3AzFM21fL/ux0kZAbTE+HDPQ46vuh0dqzhlBm6w7/029RxZLvV6bUUsAs70i2r4JfShhCjBYZ+bTjR42diFVA==",
         "dependencies": {
@@ -82,7 +82,7 @@
       },
       "Microsoft.Extensions.Logging.Debug": {
         "type": "Direct",
-        "requested": "[2.1.1, 2.2.0)",
+        "requested": "[2.1.1, )",
         "resolved": "2.1.1",
         "contentHash": "72k7rBz2DL3ev59gX+uwOmA/pEegGzi5SRZhysPIi7+2+JoyLlIRBPscJ8OzOI344Bq27cTByGHDoYWOrq73vg==",
         "dependencies": {


### PR DESCRIPTION
- Reverts some constraints added in #15 

Not sure what _official_ support policy is for `Microsoft.Extensions.*` on .NET Framework, but we shouldn't make life harder on folks who have upgraded past `2.1.x`.

- `AspNetCore.*` are still clamped to `2.1.x`.
- Example projects are still clamped to what should be supported versions so upgrade suggestions are actually useful.
