### PR TITLE
Publish Symbols for Startup

### DIFF
--- a/src/Startup/Unravel.Startup.csproj
+++ b/src/Startup/Unravel.Startup.csproj
@@ -10,7 +10,7 @@
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">


### PR DESCRIPTION
Unravel.Startup is failing to publish symbols:
> The uploaded symbols package contains one or more pdbs that are not portable.

From https://github.com/NuGet/NuGetGallery/issues/7668:

> NuGet.org's symbol server only accepts portable PDBs. You can either remove the `DebugType` property or you can set set the `DebugType` to `portable`.

